### PR TITLE
Fix map markers update when changing bulk upgrade status via star details

### DIFF
--- a/client/src/components/game/star/BulkInfrastructureUpgrade.vue
+++ b/client/src/components/game/star/BulkInfrastructureUpgrade.vue
@@ -157,11 +157,6 @@ export default {
     resetPreview (e) {
       this.hasChecked = false
       this.upgradePreview = null
-
-      if (e.starId) {
-        let star = GameHelper.getStarById(this.$store.state.game, e.starId)
-        GameContainer.reloadStar(star)
-      }
     },
     panToStar (starId) {
       let star = this.getStar(starId)

--- a/client/src/components/game/star/IgnoreBulkUpgrade.vue
+++ b/client/src/components/game/star/IgnoreBulkUpgrade.vue
@@ -36,6 +36,7 @@
 <script>
 import starService from '../../../services/api/star'
 import GameHelper from '../../../services/gameHelper'
+import GameContainer from '../../../game/container'
 
 export default {
   components: {
@@ -50,6 +51,8 @@ export default {
       this.$emit("bulkIgnoreChanged", { 
         starId: this.starId
       });
+      const star = GameHelper.getStarById(this.$store.state.game, this.starId);
+      GameContainer.reloadStar(star);
     },
     async toggleBulkIgnore (infrastructureType) {
       try {


### PR DESCRIPTION
Fixes: Updating bulk upgrade status does not update the map markers