### PR TITLE
Moved all api route `throw new ValidationError` calls inside existing…

### DIFF
--- a/server/api/auth.ts
+++ b/server/api/auth.ts
@@ -18,11 +18,11 @@ export default (router: Router, io, container: DependencyContainer) => {
             errors.push('Password is a required field');
         }
     
-        if (errors.length) {
-            throw new ValidationError(errors);
-        }
-    
         try {
+            if (errors.length) {
+                throw new ValidationError(errors);
+            }
+    
             let user = await container.authService.login(req.body.email, req.body.password);
     
             // Store the user id in the session.

--- a/server/api/badges.ts
+++ b/server/api/badges.ts
@@ -34,11 +34,11 @@ export default (router: Router, io, container: DependencyContainer) => {
             errors.push('badgeKey is required.');
         }
 
-        if (errors.length) {
-            throw new ValidationError(errors);
-        }
-
         try {
+            if (errors.length) {
+                throw new ValidationError(errors);
+            }
+
             await container.badgeService.purchaseBadgeForUser(req.session.userId, req.params.userId, req.body.badgeKey);
             
             return res.sendStatus(200);
@@ -64,11 +64,11 @@ export default (router: Router, io, container: DependencyContainer) => {
             errors.push('badgeKey is required.');
         }
 
-        if (errors.length) {
-            throw new ValidationError(errors);
-        }
-
         try {
+            if (errors.length) {
+                throw new ValidationError(errors);
+            }
+
             await container.badgeService.purchaseBadgeForPlayer(req.game, req.session.userId, req.params.playerId, req.body.badgeKey);
             
             return res.sendStatus(200);

--- a/server/api/game/carrier.ts
+++ b/server/api/game/carrier.ts
@@ -29,11 +29,11 @@ export default (router: Router, io, container: DependencyContainer) => {
             errors.push('loop field is required.');
         }
 
-        if (errors.length) {
-            throw new ValidationError(errors);
-        }
-
         try {
+            if (errors.length) {
+                throw new ValidationError(errors);
+            }
+
             await container.waypointService.loopWaypoints(
                 req.game,
                 req.player,
@@ -61,11 +61,11 @@ export default (router: Router, io, container: DependencyContainer) => {
             errors.push('starId is required.');
         }
 
-        if (errors.length) {
-            throw new ValidationError(errors);
-        }
-
         try {
+            if (errors.length) {
+                throw new ValidationError(errors);
+            }
+
             await container.shipTransferService.transfer(
                 req.game,
                 req.player,
@@ -155,11 +155,11 @@ export default (router: Router, io, container: DependencyContainer) => {
             errors.push('attacker.weaponsLevel must be greater than 0.');
         }
 
-        if (errors.length) {
-            throw new ValidationError(errors);
-        }
-
         try {
+            if (errors.length) {
+                throw new ValidationError(errors);
+            }
+
             let result = container.combatService.calculate(
                 req.body.defender,
                 req.body.attacker,

--- a/server/api/game/trade.ts
+++ b/server/api/game/trade.ts
@@ -29,11 +29,11 @@ export default (router: Router, io, container: DependencyContainer) => {
             errors.push('amount must be greater than 0.');
         }
 
-        if (errors.length) {
-            throw new ValidationError(errors);
-        }
-
         try {
+            if (errors.length) {
+                throw new ValidationError(errors);
+            }
+
             let trade = await container.tradeService.sendCredits(
                 req.game,
                 req.player,
@@ -71,11 +71,11 @@ export default (router: Router, io, container: DependencyContainer) => {
             errors.push('amount must be greater than 0.');
         }
 
-        if (errors.length) {
-            throw new ValidationError(errors);
-        }
-
         try {
+            if (errors.length) {
+                throw new ValidationError(errors);
+            }
+
             let trade = await container.tradeService.sendCreditsSpecialists(
                 req.game,
                 req.player,
@@ -109,11 +109,11 @@ export default (router: Router, io, container: DependencyContainer) => {
             errors.push('amount must be greater than 0.');
         }
 
-        if (errors.length) {
-            throw new ValidationError(errors);
-        }
-
         try {
+            if (errors.length) {
+                throw new ValidationError(errors);
+            }
+
             let trade = await container.tradeService.sendRenown(
                 req.game,
                 req.player,
@@ -138,11 +138,11 @@ export default (router: Router, io, container: DependencyContainer) => {
             errors.push('toPlayerId is required.');
         }
 
-        if (errors.length) {
-            throw new ValidationError(errors);
-        }
-
         try {
+            if (errors.length) {
+                throw new ValidationError(errors);
+            }
+
             let trade = await container.tradeService.sendTechnology(
                 req.game,
                 req.player,

--- a/server/api/guild.ts
+++ b/server/api/guild.ts
@@ -70,15 +70,15 @@ export default (router: Router, io, container: DependencyContainer) => {
     }, middleware.handleError);
 
     router.post('/api/guild', middleware.authenticate, async (req, res, next) => {
-        if (!req.body.name) {
-            throw new ValidationError(`name is required.`);
-        }
-
-        if (!req.body.tag) {
-            throw new ValidationError(`tag is required.`);
-        }
-
         try {
+            if (!req.body.name) {
+                throw new ValidationError(`name is required.`);
+            }
+
+            if (!req.body.tag) {
+                throw new ValidationError(`tag is required.`);
+            }
+
             let result = await container.guildService.create(req.session.userId, req.body.name, req.body.tag);
                 
             return res.status(201).json(result);
@@ -88,15 +88,15 @@ export default (router: Router, io, container: DependencyContainer) => {
     }, middleware.handleError);
 
     router.patch('/api/guild', middleware.authenticate, async (req, res, next) => {
-        if (!req.body.name) {
-            throw new ValidationError(`name is required.`);
-        }
-
-        if (!req.body.tag) {
-            throw new ValidationError(`tag is required.`);
-        }
-
         try {
+            if (!req.body.name) {
+                throw new ValidationError(`name is required.`);
+            }
+
+            if (!req.body.tag) {
+                throw new ValidationError(`tag is required.`);
+            }
+
             await container.guildService.rename(req.session.userId, req.body.name, req.body.tag);
                 
             return res.sendStatus(200);

--- a/server/api/report.ts
+++ b/server/api/report.ts
@@ -18,11 +18,11 @@ export default (router: Router, io, container: DependencyContainer) => {
             errors.push('reasons is a required body field');
         }
 
-        if (errors.length) {
-            throw new ValidationError(errors);
-        }
-
         try {
+            if (errors.length) {
+                throw new ValidationError(errors);
+            }
+
             await container.reportService.reportPlayer(req.game, req.body.playerId, req.session.userId, req.body.reasons);
             
             return res.sendStatus(200);

--- a/server/api/user.ts
+++ b/server/api/user.ts
@@ -183,11 +183,11 @@ export default (router: Router, io, container: DependencyContainer) => {
             errors.push('Username is a required field');
         }
 
-        if (errors.length) {
-            throw new ValidationError(errors);
-        }
-
         try {
+            if (errors.length) {
+                throw new ValidationError(errors);
+            }
+
             await container.userService.updateUsername(req.session.userId, req.body.username);
 
             return res.sendStatus(200);
@@ -203,11 +203,11 @@ export default (router: Router, io, container: DependencyContainer) => {
             errors.push('Email is a required field');
         }
 
-        if (errors.length) {
-            throw new ValidationError(errors);
-        }
-
         try {
+            if (errors.length) {
+                throw new ValidationError(errors);
+            }
+
             await container.userService.updateEmailAddress(req.session.userId, req.body.email);
 
             return res.sendStatus(200);
@@ -227,11 +227,11 @@ export default (router: Router, io, container: DependencyContainer) => {
             errors.push('New password is a required field');
         }
 
-        if (errors.length) {
-            throw new ValidationError(errors);
-        }
-
         try {
+            if (errors.length) {
+                throw new ValidationError(errors);
+            }
+
             await container.userService.updatePassword(
                 req.session.userId,
                 req.body.currentPassword,
@@ -262,11 +262,11 @@ export default (router: Router, io, container: DependencyContainer) => {
     }, middleware.handleError);
 
     router.post('/api/user/resetPassword', async (req, res, next) => {
-        if (req.body.token == null || !req.body.token.length) {
-            throw new ValidationError(`The token is required`);
-        }
-
         try {
+            if (req.body.token == null || !req.body.token.length) {
+                throw new ValidationError(`The token is required`);
+            }
+
             await container.userService.resetPassword(req.body.token, req.body.newPassword);
 
             return res.sendStatus(200);


### PR DESCRIPTION
… try/catch blocks.

expressjs doesn't automatically handle async exceptions and advises that they should be caught and propagated with next() (https://expressjs.com/en/guide/error-handling.html).

Without this, the server crashes if these validation calls are hit. The client protects against this with client side validation, but it's good to make sure the server handles them cleanly as well.