### PR TITLE
Changed the doubling of the saved value for the ignitedResources

### DIFF
--- a/server/services/carrierMovement.ts
+++ b/server/services/carrierMovement.ts
@@ -87,14 +87,15 @@ export default class CarrierMovementService {
         // Reignite dead stars if applicable
         // Note: Black holes cannot be reignited.
         if (!carrier.isGift && this.starService.isDeadStar(destinationStar) && this.specialistService.getReigniteDeadStar(carrier)) {
-            let reigniteNaturalResources = this.specialistService.getReigniteDeadStarNaturalResources(carrier);
+            let reigniteSpecialistNaturalResources = this.specialistService.getReigniteDeadStarNaturalResources(carrier);
 
-            // Double resources for binary stars.
-            if (destinationStar.isBinaryStar) {
-                reigniteNaturalResources.economy *= 2;
-                reigniteNaturalResources.industry *= 2;
-                reigniteNaturalResources.science *= 2;
-            }
+            // Double resourches for binary stars.
+            let modifier = destinationStar.isBinaryStar ? 2 : 1
+            let reigniteNaturalResources = {
+                economy: reigniteSpecialistNaturalResources.economy * modifier,
+                industry: reigniteSpecialistNaturalResources.industry * modifier,
+                science: reigniteSpecialistNaturalResources.science * modifier
+            };
             
             this.starService.reigniteDeadStar(game, destinationStar, reigniteNaturalResources);
 


### PR DESCRIPTION
The issue obviously was in the *= 2, that doubled and saved the original value when a binary star was ignited.