### PR TITLE
Fixed shortest routecalculator going straight line

### DIFF
--- a/client/src/services/waypointHelper.js
+++ b/client/src/services/waypointHelper.js
@@ -38,7 +38,7 @@ class WaypointHelper {
             const current = openSet.shift();
 
             closedSet.push(current); // We're evaluating, so might as well close it.
-
+            
             // If we've found the end, return the reversed path.
             if (current._id === end._id) {
                 let temp = current;
@@ -51,7 +51,7 @@ class WaypointHelper {
                     path.push(temp.parent);
                     temp = temp.parent;
                 }
-
+                
                 return path.reverse();
             }
 

--- a/client/src/services/waypointHelper.js
+++ b/client/src/services/waypointHelper.js
@@ -42,16 +42,16 @@ class WaypointHelper {
             // If we've found the end, return the reversed path.
             if (current._id === end._id) {
                 let temp = current;
-
+        
                 const path = [];
 
                 path.push(temp);
-
+        
                 while (temp.parent) {
                     path.push(temp.parent);
                     temp = temp.parent;
                 }
-                
+        
                 return path.reverse();
             }
 

--- a/client/src/services/waypointHelper.js
+++ b/client/src/services/waypointHelper.js
@@ -9,9 +9,7 @@ class WaypointHelper {
             return {
                 ...s,
                 cost: 0,
-                totalCost: 0,
                 costFromStart: 0,
-                estimatedCostToEnd: 0,
                 neighbors: null,
                 parent: null
             }
@@ -28,24 +26,32 @@ class WaypointHelper {
         let closedSet = []
 
         while (openSet.length) {
-            openSet.sort((a, b) => a.totalCost - b.totalCost); // Ensure we start with the node that has the lowest total cost
+            // This sort makes us look at the nodes where we can get the quickest first.
+            // This guarantees that all nodes that already have a calculated route (which may not be the quickest)
+            // will have their quickest route found. This in turn guarantees that the final fastest route can be found.
+
+            // Note from Tristanvds: Unfortunately we cannot also take into account a sorting system where we look at the
+            // distance to the end star. This kind of sorting system would favour going in a direct line towards that star
+            // instead of going for wormholes. Therefore we have to take a (computationally) slower approach by sorting
+            // based on the distance from the start.
+            openSet.sort((a, b) => a.costFromStart - b.costFromStart); // Ensure we start with the node that has the lowest total cost
             const current = openSet.shift();
 
             closedSet.push(current); // We're evaluating, so might as well close it.
-            
+
             // If we've found the end, return the reversed path.
             if (current._id === end._id) {
                 let temp = current;
-        
+
                 const path = [];
 
                 path.push(temp);
-        
+
                 while (temp.parent) {
                     path.push(temp.parent);
                     temp = temp.parent;
                 }
-        
+
                 return path.reverse();
             }
 
@@ -74,12 +80,9 @@ class WaypointHelper {
                         continue;
                     }
 
-                    // Calculate the running cost and estimated cost to the end. Ideally we want
-                    // to head in the direction of the end goal using manhattan distance.
+                    // Calculate the final cost from the start to the end
+                    // while updating the path taken.
                     neighbor.costFromStart = nextCost
-                    neighbor.estimatedCostToEnd = GameHelper.getActualTicksBetweenLocations(game, player, carrier, neighbor, end, hyperspaceDistance)
-                    // neighbor.estimatedCostToEnd = GameHelper.getTicksBetweenLocations(game, carrier, [neighbor, end])
-                    neighbor.totalCost = neighbor.costFromStart + neighbor.estimatedCostToEnd
                     neighbor.parent = current
                 }
             }


### PR DESCRIPTION
**Skip the first part if you don't really have to know what went wrong. Go directly to "In Short"**

What the calculator used to do wrong was the following:
The star on which it chose to calculate was the star that had the fewest travel time towards us **plus** the travel time it would require if you travelled in a straight line towards the destination.

This _almost_ makes it physically impossible for any calculated route to be moving away from the destination star. Making any special wormhole shortcuts _almost_ impossible to find.

This is also problematic as all calculated costs (costFromStart) of stars in the algorithm that arent closed yet could still become lower **except** the cost of the current lowest star, that one is guaranteed to be optimal.

In more detail, in the previous code it was possible that the star with the lowest totalCost had a costFromStart that was not optimised. If however you first run through all stars with a lower costFromStart, you can guarantee that the costFromStart of this star cannot be optimised (or you optimise it to a point where it cannot be optimised).

### In short:
The previous algorithm a trick was used in an attempt to be smart. This can work (sometimes) if the space you work in is Euclidian (standard, the kind of space we generally know). A space with wormholes is not. Therefore such a trick breaks down in the presence of such wormholes. The only solution I can come up with (and the brilliant minds of our time have come up with, I just copied them) is to stick to the standard algorithm which takes more time, but works guaranteed.


### Note:
I added some comments in the code about this too, I guess you should probably make those more to the point (or to your preference). Feel free to do so