### PR TITLE
Fix the invalid calculation of waitpoint delay in CarrierWaypoint.vue

### DIFF
--- a/client/src/views/game/components/carrier/CarrierWaypoint.vue
+++ b/client/src/views/game/components/carrier/CarrierWaypoint.vue
@@ -259,7 +259,8 @@ export default {
       for (let i = 0; i <= index; i++) {
         let wp = this.waypoints[i]
 
-        totalTicks += wp.ticks + +wp.delayTicks
+        // wp.ticks includes delayTicks
+        totalTicks += wp.ticks
       }
 
       this.waypointEta = GameHelper.getCountdownTimeStringByTicks(this.$store.state.game, totalTicks)


### PR DESCRIPTION
The delayTick was already included in [wp.ticks](https://github.com/solaris-games/solaris/blob/43e9ffa25960fc7d298d167fda0388094b8a32fe/server/services/waypoint.ts#L441)

https://github.com/solaris-games/solaris/issues/673