### PR TITLE
Feature/inbound attacks event

### DIFF
--- a/client/src/views/account/components/Subscriptions.vue
+++ b/client/src/views/account/components/Subscriptions.vue
@@ -65,6 +65,16 @@
                         </select>
                     </div>
                 </div>
+
+                <div class="row pt-1 pb-1">
+                    <label for="playerInboundAttacks" class="col-12 col-sm-6 col-form-label">Game - Incoming Attacks</label>
+                    <div class="col-12 col-sm-6">
+                        <select class="form-control" id="playerInboundAttacks" v-model="subscriptions.discord.playerInboundAttacks" :disabled="isSaving">
+                            <option :value="true">Enabled</option>
+                            <option :value="false">Disabled</option>
+                        </select>
+                    </div>
+                </div>
                 
                 <div class="row pt-1 pb-1">
                     <label for="playerRenownReceived" class="col-12 col-sm-6 col-form-label">Game - Renown Received</label>

--- a/client/src/views/game/components/eventLog/events/EventsListItem.vue
+++ b/client/src/views/game/components/eventLog/events/EventsListItem.vue
@@ -41,6 +41,7 @@
         <player-gift-sent :event="event" v-if="event.type === 'playerGiftSent'"
             @onOpenPlayerDetailRequested="onOpenPlayerDetailRequested"/>
         <player-galactic-cycle-complete :event="event" v-if="event.type === 'playerGalacticCycleComplete'"/>
+        <player-inbound-attacks :event="event" v-if="event.type === 'playerInboundAttacks'"/>
         <player-renown-received :event="event" v-if="event.type === 'playerRenownReceived'"
             @onOpenPlayerDetailRequested="onOpenPlayerDetailRequested"/>
         <player-renown-sent :event="event" v-if="event.type === 'playerRenownSent'"
@@ -88,6 +89,7 @@ import PlayerCreditsSpecialistsSentVue from './PlayerCreditsSpecialistsSent'
 import PlayerGiftReceivedVue from './PlayerGiftReceived'
 import PlayerGiftSentVue from './PlayerGiftSent'
 import PlayerGalacticCycleCompleteEventVue from './PlayerGalacticCycleCompleteEvent'
+import PlayerInboundAttacksEventVue from './PlayerInboundAttacksEvent'
 import PlayerRenownReceivedVue from './PlayerRenownReceived'
 import PlayerRenownSentVue from './PlayerRenownSent'
 import PlayerResearchCompleteVue from './PlayerResearchComplete'
@@ -130,6 +132,8 @@ export default {
     'player-gift-received': PlayerGiftReceivedVue,
     'player-gift-sent': PlayerGiftSentVue,
     'player-galactic-cycle-complete': PlayerGalacticCycleCompleteEventVue,
+    'player-inbound-attacks': PlayerInboundAttacksEventVue,
+
     'player-renown-received': PlayerRenownReceivedVue,
     'player-renown-sent': PlayerRenownSentVue,
     'player-research-complete': PlayerResearchCompleteVue,

--- a/client/src/views/game/components/eventLog/events/PlayerInboundAttacksEvent.vue
+++ b/client/src/views/game/components/eventLog/events/PlayerInboundAttacksEvent.vue
@@ -1,0 +1,130 @@
+<template>
+  <div>
+    <p>
+      Hostile carriers sighted en route to your stars
+    </p>
+
+    <span v-if="flattenedAttacks && carrierTimers">
+
+      <table class="table table-sm">
+
+        <thead class="table-dark">
+          <th>Star</th>
+          <th>Attacker</th>
+          <th>Ships</th>
+          <th class="text-end">ETA</th>
+        </thead>
+
+        <tbody>
+          <tr v-for="attack of flattenedAttacks" :key="attack.carrier._id">
+            <td>
+              <star-label :starId="attack.star._id" :starName="getStarById(attack.star._id).name" />
+            </td>
+            <td>
+              <a href="javascript:;" @click="onOpenPlayerDetailRequested(attack.carrier.ownedByPlayerId)">
+                {{ getPlayerById(attack.carrier.ownedByPlayerId).alias }}
+              </a>
+            </td>
+            <td>
+              <a href="javascript:;" @click="onOpenCarrierDetailRequested(attack.carrier._id)">
+                <specialist-icon :type="'carrier'" :defaultIcon="'rocket'"
+                  :specialist="attack.carrier.specialist"></specialist-icon>
+                {{ attack.carrier.ships }}
+              </a>
+            </td>
+            <td class="text-end">
+              {{ carrierTimers.find(c => c.id === attack.carrier._id).timeRemainingEta }}
+            </td>
+          </tr>
+
+        </tbody>
+      </table>
+    </span>
+
+  </div>
+</template>
+
+<script>
+
+import GameHelper from '../../../../../services/gameHelper'
+import StarLabelVue from '../../star/StarLabel'
+import SpecialistIconVue from '../../specialist/SpecialistIcon.vue'
+
+export default {
+  components: {
+    'star-label': StarLabelVue,
+    'specialist-icon': SpecialistIconVue,
+  },
+  props: {
+    event: Object
+  },
+  data() {
+    return {
+      flattenedAttacks: null,
+      carrierTimers: null,
+      intervalFunction: null,
+    }
+  },
+  mounted() {
+
+    this.flattenedAttacks = this.event.data.inboundAttacks.starsUnderAttack
+      .flatMap(item => item.attackers.map(attacker => {
+        return {
+          carrier: attacker,
+          star: item.star,
+        }
+      })).sort((a,b) => b.carrier.ships - a.carrier.ships);
+
+    const flattenedCarrierIds = this.flattenedAttacks.map(a => a.carrier._id)
+
+    this.carrierTimers = flattenedCarrierIds.map(id => {
+      let c = GameHelper.getCarrierById(this.$store.state.game, id)
+
+      return {
+        id: id,
+        carrier: c,
+        timeRemainingEta: ''
+      }
+    })
+
+    this.recalculateTimeRemaining()
+
+    if (GameHelper.isGameInProgress(this.$store.state.game) || GameHelper.isGamePendingStart(this.$store.state.game)) {
+      this.intervalFunction = setInterval(this.recalculateTimeRemaining, 500)
+      this.recalculateTimeRemaining()
+    }
+  },
+  destroyed() {
+    clearInterval(this.intervalFunction)
+  },
+  methods: {
+    getPlayerById(playerId) {
+      return GameHelper.getPlayerById(this.$store.state.game, playerId)
+    },
+    getStarById(starId) {
+      return GameHelper.getStarById(this.$store.state.game, starId)
+    },
+    recalculateTimeRemaining() {
+      for (let timerData of this.carrierTimers) {
+        let carrier = timerData.carrier
+        if (carrier.ticksEta) {
+          let timeString = GameHelper.getCountdownTimeStringByTicks(this.$store.state.game, carrier.ticksEta)
+          timerData.timeRemainingEta = timeString
+        }
+
+      }
+    },
+    onOpenPlayerDetailRequested(e) {
+      console.log(`onOpenPlayerDetailRequested ${JSON.stringify(e)}`)
+      //this works which shows that e is a valid player id
+      console.log(this.getPlayerById(e).alias)
+      this.$emit('onOpenPlayerDetailRequested', e)
+    },
+    onOpenCarrierDetailRequested(e) {
+      this.$emit('onOpenCarrierDetailRequested', e)
+    },
+  }
+}
+</script>
+
+<style scoped></style>

--- a/server/db/models/schemas/star.ts
+++ b/server/db/models/schemas/star.ts
@@ -35,7 +35,8 @@ const schema = new Schema({
     location: {
         x: { type: Types.Number, required: true, default: 0 },
         y: { type: Types.Number, required: true, default: 0 }
-    }
+    },
+    inboundAttacksNotified: [{ type: Types.ObjectId, required: false, default: [] }], // carrier ids
 });
 
 export default schema;

--- a/server/services/gameTick.ts
+++ b/server/services/gameTick.ts
@@ -28,7 +28,7 @@ import { Star } from "./types/Star";
 import { GameRankingResult } from "./types/Rating";
 import DiplomacyUpkeepService from "./diplomacyUpkeep";
 import CarrierGiftService from "./carrierGift";
-import CarrierMovementService from "./carrierMovement";
+import CarrierMovementService, { CarrierMovementReport } from "./carrierMovement";
 import PlayerCycleRewardsService from "./playerCycleRewards";
 import StarContestedService from "./starContested";
 import PlayerReadyService from "./playerReady";
@@ -38,6 +38,8 @@ import GamePlayerAFKEvent from "./types/events/GamePlayerAFK";
 import GameEndedEvent from "./types/events/GameEnded";
 import PlayerAfkService from "./playerAfk";
 import ShipService from "./ship";
+import { Specialist } from "./types/Specialist";
+import InboundAttacksService from "./inboundAttacks";
 
 const EventEmitter = require('events');
 const moment = require('moment');
@@ -81,7 +83,8 @@ export default class GameTickService extends EventEmitter {
     starContestedService: StarContestedService;
     playerReadyService: PlayerReadyService;
     shipService: ShipService;
-    
+    inboundAttacksService: InboundAttacksService
+
     constructor(
         distanceService: DistanceService,
         starService: StarService,
@@ -111,10 +114,12 @@ export default class GameTickService extends EventEmitter {
         carrierGiftService: CarrierGiftService,
         starContestedService: StarContestedService,
         playerReadyService: PlayerReadyService,
-        shipService: ShipService
+        shipService: ShipService,
+        inboundAttacksService: InboundAttacksService
+
     ) {
         super();
-            
+
         this.distanceService = distanceService;
         this.starService = starService;
         this.carrierService = carrierService;
@@ -144,6 +149,7 @@ export default class GameTickService extends EventEmitter {
         this.starContestedService = starContestedService;
         this.playerReadyService = playerReadyService;
         this.shipService = shipService;
+        this.inboundAttacksService = inboundAttacksService;
     }
 
     async tick(gameId: DBObjectId) {
@@ -556,6 +562,9 @@ export default class GameTickService extends EventEmitter {
                     star: carrierMovementReport.destinationStar,
                     waypoint: carrierMovementReport.waypoint
                 });
+
+                // Unset inboundAttack notification - if there is ever a way to reroute a carrier mid flight, this will need to be called there too
+                await this.inboundAttacksService.unsetNotificationFlag(game, carrierInTransit)
             }
 
             // Check if combat is required, if so add the destination star to the array of combat stars to check later.
@@ -590,6 +599,9 @@ export default class GameTickService extends EventEmitter {
         // 4c. Do the rest of the waypoint actions.
         this.waypointService.performWaypointActionsCollects(game, actionWaypoints);
         this.waypointService.performWaypointActionsGarrisons(game, actionWaypoints);
+
+        // 5. Send inbound attacks notifications
+        this.inboundAttacksService.notifyInboundAttacks(game);
 
         // TODO: This is incredibly inefficient in large turn based games; moved it outside the main tick loop
         // for performance reasons because it needs to calculate the scanning ranges of all players.

--- a/server/services/inboundAttacks.ts
+++ b/server/services/inboundAttacks.ts
@@ -1,0 +1,168 @@
+
+import EventEmitter from "events";
+import CarrierService from "./carrier";
+import DiplomacyService from "./diplomacy";
+import { Carrier } from "./types/Carrier";
+import { DBObjectId } from "./types/DBObjectId";
+import { Game } from "./types/Game";
+import { Star } from "./types/Star";
+import PlayerInboundAttacksEvent from "./types/events/PlayerInboundAttacksEvent";
+import StarService from "./star";
+import SpecialistService from "./specialist";
+
+export const InboundAttacksServiceEvents = {
+    onPlayerInboundAttacks: 'onPlayerInboundAttacks',
+}
+
+export interface InboundAttacks {
+    playerId: DBObjectId,
+    starsUnderAttack: {
+        star: Star,
+        attackers: Carrier[]
+    }[]
+}
+
+export default class InboundAttacksService extends EventEmitter {
+
+    diplomacyService: DiplomacyService;
+    carrierService: CarrierService;
+    starService: StarService;
+    specialistService: SpecialistService;
+
+    constructor(
+        diplomacyService: DiplomacyService,
+        carrierService: CarrierService,
+        starService: StarService,
+        specialistService: SpecialistService
+    ) {
+        super()
+        this.diplomacyService = diplomacyService;
+        this.carrierService = carrierService;
+        this.starService = starService;
+        this.specialistService = specialistService;
+    }
+
+    notifyInboundAttacks(game: Game) {
+
+        let inboundAttacks: InboundAttacks[] = this._getInboundAttacks(game);
+
+        for (let playerUnderAttack of inboundAttacks) {
+            let e: PlayerInboundAttacksEvent = {
+                gameId: game._id,
+                gameTick: game.state.tick,
+                playerId: playerUnderAttack.playerId,
+                inboundAttacks: playerUnderAttack
+            }
+            this.emit(InboundAttacksServiceEvents.onPlayerInboundAttacks, e);
+        }
+    }
+
+    // Sets carrier->star notification flag
+    // Don't do this directly from notifyInboundAttacks, let notificationService do it after success
+    async setNotificationFlag(game: Game, carrier: Carrier) {
+        let destinationStar = this._getCarrierDestination(game, carrier)
+        if (!destinationStar) return
+        await this.starService.addInboundAttackNotified(game, destinationStar, carrier._id)
+    }
+
+    // Unsets carrier->star notification flag
+    // gameTickService knows when ships move, so call it from there
+    async unsetNotificationFlag(game: Game, carrier: Carrier) {
+        let destinationStar = this._getCarrierDestination(game, carrier)
+        if (!destinationStar) return
+        await this.starService.removeInboundAttackNotified(game, destinationStar, carrier._id)
+    }
+
+    _getInboundAttacks(game: Game): InboundAttacks[] {
+        let movingCarriers = game.galaxy.carriers.filter(c => c.waypoints.length);
+
+        let attackingCarriers = movingCarriers
+            .filter(c => this._checkForVisibleAttack(game, c))
+            .filter(c => !this._checkForAlreadyNotified(game, c))
+
+        let inboundAttacks: InboundAttacks[] = []
+        // Build inboundAttacks struct
+        for (let carrier of attackingCarriers) {
+
+            let destinationStar = this._getCarrierDestination(game, carrier)
+            if (!destinationStar) continue;
+
+            let defenderPlayerId = destinationStar!.ownedByPlayerId
+
+            let playerUnderAttack = inboundAttacks!.find(p => p.playerId.toString() === defenderPlayerId?.toString())
+
+            if (!playerUnderAttack) {
+                playerUnderAttack = {
+                    playerId: destinationStar.ownedByPlayerId!,
+                    starsUnderAttack: []
+                }
+                inboundAttacks.push(playerUnderAttack)
+            }
+
+            let starUnderAttack = inboundAttacks
+                .find(p => p.playerId.toString() === defenderPlayerId?.toString())?.starsUnderAttack
+                .find(s => s.star._id.toString() === destinationStar!._id.toString())
+
+            if (!starUnderAttack) {
+                starUnderAttack = {
+                    star: destinationStar,
+                    attackers: []
+                }
+                inboundAttacks.find(p => p.playerId.toString() === defenderPlayerId?.toString())?.starsUnderAttack.push(starUnderAttack)
+            }
+
+            // Have to manually load specialist here for client?
+            if (carrier.specialistId) {
+                carrier = JSON.parse(JSON.stringify(carrier)) // some better way to get the carrier to load it's specialist data?
+                carrier.specialist = this.specialistService.getByIdCarrier(carrier.specialistId)
+            }
+
+            inboundAttacks
+                .find(p => p.playerId.toString() === defenderPlayerId?.toString())?.starsUnderAttack
+                .find(s => s.star._id.toString() === destinationStar!._id.toString())?.attackers
+                .push(carrier)
+        }
+
+        return inboundAttacks
+    }
+
+    _checkForVisibleAttack(game: Game, carrier: Carrier): boolean {
+        let destinationStar = this._getCarrierDestination(game, carrier)
+        if (!destinationStar) return false
+
+        let carrierOwner = carrier.ownedByPlayerId
+        let destinationOwner = destinationStar?.ownedByPlayerId
+
+        // Check if the star and carrier are owned by the same player
+        if (!destinationOwner || (carrierOwner === destinationOwner)) return false
+
+        // Check if the carrier is a gift
+        if (carrier.isGift) return false
+
+        // Check if the carrier hasn't left yet
+        if(carrier.orbiting) return false
+
+        // Check if the players are allied
+        if (this.diplomacyService.isDiplomaticStatusBetweenPlayersAllied(game, [carrierOwner!, destinationOwner!])) return false
+
+        // Check if the attacked player cannot see the carrier
+        let visibleCarriers = this.carrierService.filterCarriersByScanningRange(game, [destinationOwner!]) ?? []
+        if (!visibleCarriers.some(c => c._id.toString() === carrier._id.toString())) return false
+
+        // If a carrier fights and dies (carrier to carrier seems possible) on the same tick it would be visible, do we want to send notification still? 
+        // or are waypoints cleared already for a newly dead carrier?
+        return true
+
+    }
+
+    _checkForAlreadyNotified(game: Game, carrier: Carrier) {
+        let destinationStar = this._getCarrierDestination(game, carrier)
+        return destinationStar?.inboundAttacksNotified?.some(c => c.toString() === carrier._id.toString())
+    }
+
+    _getCarrierDestination(game: Game, carrier: Carrier): Star | undefined {
+        if (!carrier?.waypoints?.[0]) return undefined
+        return game.galaxy.stars.find(s => s._id.toString() === carrier.waypoints[0].destination.toString());
+    }
+
+}

--- a/server/services/index.ts
+++ b/server/services/index.ts
@@ -95,6 +95,7 @@ import { GameEvent } from './types/GameEvent';
 import { Guild } from './types/Guild';
 import { Payment } from './types/Payment';
 import { Report } from './types/Report';
+import InboundAttacksService from './inboundAttacks';
 
 const gameNames = require('../config/game/gameNames');
 const starNames = require('../config/game/starNames');
@@ -183,19 +184,20 @@ export default (config, io): DependencyContainer => {
     const battleRoyaleService = new BattleRoyaleService(starService, carrierService, mapService, starDistanceService, waypointService, carrierMovementService);
     const starMovementService = new StarMovementService(mapService, starDistanceService, specialistService, waypointService);
     const gameGalaxyService = new GameGalaxyService(cacheService, broadcastService, gameService, mapService, playerService, playerAfkService, starService, shipService, distanceService, starDistanceService, starUpgradeService, carrierService, waypointService, researchService, specialistService, technologyService, reputationService, guildUserService, historyService, battleRoyaleService, starMovementService, gameTypeService, gameStateService, diplomacyService, avatarService, playerStatisticsService, gameFluxService, spectatorService);
-    const gameTickService = new GameTickService(distanceService, starService, carrierService, researchService, playerService, playerAfkService, historyService, waypointService, combatService, leaderboardService, userService, gameService, technologyService, specialistService, starUpgradeService, reputationService, aiService, battleRoyaleService, starMovementService, diplomacyService, gameTypeService, gameStateService, playerCycleRewardsService, diplomacyUpkeepService, carrierMovementService, carrierGiftService, starContestedService, playerReadyService, shipService);
+    const playerInboundAttacksService = new InboundAttacksService(diplomacyService, carrierService, starService, specialistService);
+    const gameTickService = new GameTickService(distanceService, starService, carrierService, researchService, playerService, playerAfkService, historyService, waypointService, combatService, leaderboardService, userService, gameService, technologyService, specialistService, starUpgradeService, reputationService, aiService, battleRoyaleService, starMovementService, diplomacyService, gameTypeService, gameStateService, playerCycleRewardsService, diplomacyUpkeepService, carrierMovementService, carrierGiftService, starContestedService, playerReadyService, shipService, playerInboundAttacksService);
     const emailService = new EmailService(config, gameService, gameJoinService, userService, leaderboardService, playerService, playerReadyService, gameTypeService, gameStateService, gameTickService);
     const eventService = new EventService(EventModel, eventRepository, broadcastService, gameService, gameJoinService, gameTickService, researchService, starService, starUpgradeService, tradeService,
-        ledgerService, conversationService, combatService, specialistService, badgeService, carrierGiftService, diplomacyService);
+        ledgerService, conversationService, combatService, specialistService, badgeService, carrierGiftService, diplomacyService, playerInboundAttacksService);
 
     const gameListService = new GameListService(gameRepository, gameService, conversationService, eventService, gameTypeService, leaderboardService);
     const gameCreateValidationService = new GameCreateValidationService(playerService, starService, carrierService, specialistService, gameTypeService);
     const gameCreateService = new GameCreateService(GameModel, gameJoinService, gameListService, nameService, mapService, playerService, passwordService, conversationService, historyService, achievementService, userService, gameCreateValidationService, gameFluxService, specialistBanService, specialStarBanService, gameTypeService, starService);
 
-    const notificationService = new NotificationService(config, userRepository, gameRepository, discordService, conversationService, gameService, gameJoinService, gameTickService, researchService, tradeService);
+    const notificationService = new NotificationService(config, userRepository, gameRepository, discordService, conversationService, gameService, gameJoinService, gameTickService, researchService, tradeService, starService, playerInboundAttacksService);
 
     console.log('Dependency container initialized.');
-    
+
     return {
         config,
         adminService,

--- a/server/services/notification.ts
+++ b/server/services/notification.ts
@@ -16,19 +16,23 @@ import GameEndedEvent from './types/events/GameEnded';
 import GameTurnEndedEvent from './types/events/GameTurnEnded';
 import ConversationMessageSentEvent from './types/events/ConversationMessageSent';
 import GameJoinService, { GameJoinServiceEvents } from './gameJoin';
+import PlayerInboundAttacksEvent from './types/events/PlayerInboundAttacksEvent';
+import StarService from './star';
+import InboundAttacksService, { InboundAttacksServiceEvents } from './inboundAttacks';
 
 // Note: We only support discord subscriptions at this point, if any new ones are added
 // this class will need to be refactored to use something like the strategy pattern.
 type SubscriptionType = 'discord';
-type SubscriptionEvent = 'gameStarted'|
-    'gameEnded'|
-    'gameTurnEnded'|
-    'playerGalacticCycleComplete'|
-    'playerResearchComplete'|
-    'playerTechnologyReceived'|
-    'playerCreditsReceived'|
-    'playerCreditsSpecialistsReceived'|
-    'playerRenownReceived'|
+type SubscriptionEvent = 'gameStarted' |
+    'gameEnded' |
+    'gameTurnEnded' |
+    'playerGalacticCycleComplete' |
+    'playerInboundAttacks' |
+    'playerResearchComplete' |
+    'playerTechnologyReceived' |
+    'playerCreditsReceived' |
+    'playerCreditsSpecialistsReceived' |
+    'playerRenownReceived' |
     'conversationMessageSent';
 
 export default class NotificationService {
@@ -42,6 +46,8 @@ export default class NotificationService {
     gameTickService: GameTickService;
     researchService: ResearchService;
     tradeService: TradeService;
+    starService: StarService;
+    inboundAttacksService: InboundAttacksService;
 
     constructor(
         config: Config,
@@ -53,7 +59,9 @@ export default class NotificationService {
         gameJoinService: GameJoinService,
         gameTickService: GameTickService,
         researchService: ResearchService,
-        tradeService: TradeService
+        tradeService: TradeService,
+        starService: StarService,
+        inboundAttacksService: InboundAttacksService
     ) {
         this.config = config;
         this.userRepo = userRepo;
@@ -65,6 +73,8 @@ export default class NotificationService {
         this.gameTickService = gameTickService;
         this.researchService = researchService;
         this.tradeService = tradeService;
+        this.starService = starService;
+        this.inboundAttacksService = inboundAttacksService
     }
 
     initialize() {
@@ -80,6 +90,7 @@ export default class NotificationService {
             this.tradeService.on(TradeServiceEvents.onPlayerCreditsSpecialistsReceived, (args) => this.onPlayerCreditsSpecialistsReceived(args.gameId, args.fromPlayer, args.toPlayer, args.amount));
             this.tradeService.on(TradeServiceEvents.onPlayerRenownReceived, (args) => this.onPlayerRenownReceived(args.gameId, args.fromPlayer, args.toPlayer, args.amount));
             this.tradeService.on(TradeServiceEvents.onPlayerTechnologyReceived, (args) => this.onPlayerTechnologyReceived(args.gameId, args.fromPlayer, args.toPlayer, args.technology));
+            this.inboundAttacksService.on(InboundAttacksServiceEvents.onPlayerInboundAttacks, (args) => this.onPlayerInboundAttacks(args));
 
             console.log('Notifications initialized.')
         }
@@ -254,9 +265,24 @@ export default class NotificationService {
             });
     }
 
+    async onPlayerInboundAttacks(args: PlayerInboundAttacksEvent) {
+        // Send the inbound attacks notification for Discord subscription to the player.
+        await this._trySendNotifications(args.gameId, [args.playerId!.toString()], 'discord', 'playerInboundAttacks',
+            async (game: Game, user: User) => {
+
+                //TODO build a real discord message, this is a placeholder
+
+                let starNames = args.inboundAttacks.starsUnderAttack.map(a => a.star.name)
+                const template = this._generateBaseDiscordMessageTemplate(game, 'Incoming Attack', `Some (${starNames.length}) of your stars are under attack! ${starNames}` );
+
+
+                await this.discordService.sendMessageOAuth(user, template);
+            });
+    }
+
     async onPlayerResearchCompleted(gameId: DBObjectId, playerId: DBObjectId, technologyKey: string, technologyLevel: number, technologyKeyNext: string, technologyLevelNext: number) {
         // Send the research completed notification for Discord subscription to the player.
-        await this._trySendNotifications(gameId, [playerId.toString()], 'discord', 'playerResearchComplete', 
+        await this._trySendNotifications(gameId, [playerId.toString()], 'discord', 'playerResearchComplete',
             async (game: Game, user: User) => {
                 const template = this._generateBaseDiscordMessageTemplate(game, 'Research Complete', 'You have finished researching a technology.');
 

--- a/server/services/star.ts
+++ b/server/services/star.ts
@@ -886,4 +886,36 @@ export default class StarService extends EventEmitter {
             starB.specialistId = null;
         }
     }
+
+    async addInboundAttackNotified(game: Game, star: Star, carrierId: DBObjectId) {
+        
+        if(star.inboundAttacksNotified?.some(c => c.toString() === carrierId.toString())) {
+            // Should not happen
+            console.log('addInboundAttackNotified this star already notified this carrier attack')
+            return;
+        }
+
+        await this.gameRepo.updateOne({
+            _id: game._id,
+            'galaxy.stars._id': star._id
+        }, {
+            $set: {
+                'galaxy.stars.$.inboundAttacksNotified': [...star.inboundAttacksNotified!, carrierId],
+            }
+        });
+
+    }
+
+    async removeInboundAttackNotified(game: Game, star: Star, carrierId: DBObjectId) {
+        if (!star.inboundAttacksNotified) return
+        let inboundAttacksNotified = star.inboundAttacksNotified.filter((c) => c !== carrierId);
+        await this.gameRepo.updateOne({
+            _id: game._id,
+            'galaxy.stars._id': star._id
+        }, {
+            $set: {
+                'galaxy.stars.$.inboundAttacksNotified': inboundAttacksNotified
+            }
+        });
+    }
 }

--- a/server/services/types/Star.ts
+++ b/server/services/types/Star.ts
@@ -55,6 +55,7 @@ export interface Star extends MapObject {
     manufacturing?: number;
     isInScanningRange?: boolean;
     effectiveTechs?: PlayerTechnologyLevels;
+    inboundAttacksNotified?: DBObjectId[];
 };
 
 export interface StarCaptureResult {

--- a/server/services/types/User.ts
+++ b/server/services/types/User.ts
@@ -41,6 +41,7 @@ export interface UserSubscriptions {
         gameEnded: boolean;
         gameTurnEnded: boolean;
         playerGalacticCycleComplete: boolean;
+        playerInboundAttack: boolean;
         playerResearchComplete: boolean;
         playerTechnologyReceived: boolean;
         playerCreditsReceived: boolean;

--- a/server/services/types/events/PlayerInboundAttacksEvent.ts
+++ b/server/services/types/events/PlayerInboundAttacksEvent.ts
@@ -1,0 +1,7 @@
+
+import { InboundAttacks } from "../../inboundAttacks";
+import { BaseGameEvent } from "./BaseGameEvent";
+
+export default interface PlayerInboundAttacksEvent extends BaseGameEvent {
+    inboundAttacks: InboundAttacks
+};

--- a/server/services/user.ts
+++ b/server/services/user.ts
@@ -446,6 +446,7 @@ export default class UserService extends EventEmitter {
                 playerCreditsReceived: subscriptions.discord.playerCreditsReceived || false,
                 playerCreditsSpecialistsReceived: subscriptions.discord.playerCreditsSpecialistsReceived || false,
                 playerGalacticCycleComplete: subscriptions.discord.playerGalacticCycleComplete || false,
+                playerInboundAttack: subscriptions.discord.playerInboundAttack || false,
                 playerRenownReceived: subscriptions.discord.playerRenownReceived || false,
                 playerResearchComplete: subscriptions.discord.playerResearchComplete || false,
                 playerTechnologyReceived: subscriptions.discord.playerTechnologyReceived || false,


### PR DESCRIPTION
Added an event (and notification) for carriers detected moving towards your stars

SERVER
carrier attacking star notification flag stored on star, maybe this needs to move
need someone to finish and test discord message, currently just a placeholder
carrier.specialist not populated when I get carrier from game.galaxy.carriers so I'm loading it manually
being traded scanning mid tick currently not hooked up to this, you should see event next tick though until it is
please double check the _checkForVisibleAttack logic, I haven't played this game very much :small_airplane: 
is there automated testing for events?

CLIENT
unable to get openPlayerDetailsRequested to work
unable to get openCarriersDetailsRequested to work
unable to test user notification settings for this event (because no discord integration)
phrasing and design should be definitely reviewed
