### PR TITLE
carrierSpeed units in GameSettings.vue fix

### DIFF
--- a/client/src/views/game/components/settings/GameSettings.vue
+++ b/client/src/views/game/components/settings/GameSettings.vue
@@ -288,7 +288,7 @@
             v-if="game.settings.galaxy.galaxyType !== 'custom'"/>
           <game-setting-value title="Carrier Speed"
             tooltip="Carriers go brrr"
-            :valueText="(game.settings.specialGalaxy.carrierSpeed / game.constants.distances.lightYear)+'/ly tick'"
+            :valueText="(game.settings.specialGalaxy.carrierSpeed / game.constants.distances.lightYear)+' ly/tick'"
             :value="game.settings.specialGalaxy.carrierSpeed"
             :compareValue="compareSettings.specialGalaxy.carrierSpeed"/>
           <game-setting-value title="Star Capture Rewards"


### PR DESCRIPTION
y/tick, not /ly tick