### PR TITLE
Fixed issue in extra dark games

### DIFF
--- a/server/services/gameGalaxy.ts
+++ b/server/services/gameGalaxy.ts
@@ -202,7 +202,7 @@ export default class GameGalaxyService {
         // dark mode games.
         if (this.gameTypeService.isDarkModeExtra(game)) {
             this._setPlayerStats(game);
-            delete game.state.leaderboard;
+            game.state.leaderboard = null;
         }
 
         // If any kind of dark mode, remove the galaxy center from the constants.

--- a/server/services/gameGalaxy.ts
+++ b/server/services/gameGalaxy.ts
@@ -198,8 +198,11 @@ export default class GameGalaxyService {
         // can't see and therefore global stats should display what the current player can see
         // instead of their actual values.
         // TODO: Better to not overwrite, but just not do it above in the first place?
+        // Also, remove the leaderboard, since it should not be visible to players in extra
+        // dark mode games.
         if (this.gameTypeService.isDarkModeExtra(game)) {
             this._setPlayerStats(game);
+            delete game.state.leaderboard;
         }
 
         // If any kind of dark mode, remove the galaxy center from the constants.


### PR DESCRIPTION
Removed state.leaderboard in extra dark games, as that information should not be accessible in this game type.