### PR TITLE
Fixes004

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,14 @@
+# These are supported funding model platforms
+
+github: # Replace with up to 4 GitHub Sponsors-enabled usernames e.g., [user1, user2]
+patreon: # Replace with a single Patreon username
+open_collective: # Replace with a single Open Collective username
+ko_fi: # Replace with a single Ko-fi username
+tidelift: # Replace with a single Tidelift platform-name/package-name e.g., npm/babel
+community_bridge: # Replace with a single Community Bridge project-name e.g., cloud-foundry
+liberapay: # Replace with a single Liberapay username
+issuehunt: # Replace with a single IssueHunt username
+lfx_crowdfunding: # Replace with a single LFX Crowdfunding project-name e.g., cloud-foundry
+polar: # Replace with a single Polar username
+buy_me_a_coffee: limitingfactor
+custom: # Replace with up to 4 custom sponsorship URLs e.g., ['link1', 'link2']

--- a/client/src/game/carrier.js
+++ b/client/src/game/carrier.js
@@ -312,17 +312,23 @@ class Carrier extends EventEmitter {
     }
   }
 
-  onClicked (e) {
-    if (e && e.data && e.data.originalEvent && e.data.originalEvent.button === 2) {
-      this.emit('onCarrierRightClicked', this.data)
-    } else {
-      let eventData = e ? e.data : null
+  onClicked(e, tryMultiSelect) {
+    setTimeout(() => {
+      if (e && e.data && e.data.originalEvent && e.data.originalEvent.button === 2) {
+        this.emit('onCarrierRightClicked', this.data)
+      } else {
+        let eventData = e ? e.data : null
 
-      this.emit('onCarrierClicked', {carrierData: this.data, eventData})
+        this.emit('onCarrierClicked', {
+          carrierData: this.data,
+          eventData,
+          tryMultiSelect
+        })
 
-      // Need to do this otherwise sometimes text gets highlighted.
-      this.deselectAllText()
-    }
+        // Need to do this otherwise sometimes text gets highlighted.
+        this.deselectAllText()
+      }
+    }, 25)
   }
 
   updateVisibility() {

--- a/client/src/game/map.js
+++ b/client/src/game/map.js
@@ -622,14 +622,14 @@ class Map extends EventEmitter {
   clickStar (starId) {
     let star = this.stars.find(s => s.data._id === starId)
 
-    star.onClicked()
+    star.onClicked(null, false)
     star.select()
   }
 
   clickCarrier (carrierId) {
     let carrier = this.carriers.find(s => s.data._id === carrierId)
 
-    carrier.onClicked()
+    carrier.onClicked(null, false)
     carrier.select()
   }
 
@@ -777,7 +777,7 @@ class Map extends EventEmitter {
           this.unselectAllCarriers()
           this.unselectAllStarsExcept(selectedStar)
 
-          if (!this.tryMultiSelect(e.location)) {
+          if (!dic.tryMultiSelect || !this.tryMultiSelect(e.location)) {
             selectedStar.toggleSelected()
             this.emit('onStarClicked', e)
           }
@@ -819,13 +819,6 @@ class Map extends EventEmitter {
     let e = dic.carrierData
     // Clicking carriers should only raise events to the UI if in galaxy mode.
     if (this.mode === 'galaxy') {
-      // If the carrier is in orbit, pass the click over to the star instead.
-      if (e.orbiting) {
-        let star = this.stars.find(x => x.data._id === e.orbiting)
-        let eventData = dic ? dic.eventData : null
-
-        return this.onStarClicked({starData: star.data, eventData})
-      }
 
       let selectedCarrier = this.carriers.find(x => x.data._id === e._id)
 
@@ -834,7 +827,7 @@ class Map extends EventEmitter {
 
       selectedCarrier.toggleSelected()
 
-      if (!this.tryMultiSelect(e.location)) {
+      if (!dic.tryMultiSelect || !this.tryMultiSelect(e.location)) {
         this.emit('onCarrierClicked', e)
       } else {
         selectedCarrier.unselect()

--- a/client/src/game/star.js
+++ b/client/src/game/star.js
@@ -781,29 +781,32 @@ class Star extends EventEmitter {
      }
   }
 
-  onClicked (e) {
-    let eventData = e ? e.data : null
+  onClicked(e, tryMultiSelect = true) {
+    setTimeout(() => {
+      let eventData = e ? e.data : null
 
-    if (e && e.data && e.data.originalEvent && e.data.originalEvent.button === 2) {
-      this.emit('onStarRightClicked', {
-        starData: this.data,
-        eventData
-      })
-    } else {
-      this.emit('onStarClicked', {
-        starData: this.data,
-        eventData,
-        permitCallback: () => {
-          // Need to do this otherwise sometimes text gets highlighted.
-          this.deselectAllText()
+      if (e && e.data && e.data.originalEvent && e.data.originalEvent.button === 2) {
+        this.emit('onStarRightClicked', {
+          starData: this.data,
+          eventData
+        })
+      } else {
+        this.emit('onStarClicked', {
+          starData: this.data,
+          tryMultiSelect,
+          eventData,
+          permitCallback: () => {
+            // Need to do this otherwise sometimes text gets highlighted.
+            this.deselectAllText()
 
-          if (this._getStarPlayer()) {
-            this.updateVisibility()
-            // this.setScale()
+            if (this._getStarPlayer()) {
+              this.updateVisibility()
+              // this.setScale()
+            }
           }
-        }
-      })
-    }
+        })
+      }
+    }, 25);
   }
 
   updateVisibility() {

--- a/client/src/services/gameHelper.js
+++ b/client/src/services/gameHelper.js
@@ -41,7 +41,11 @@ class GameHelper {
     return game.galaxy.players.find(x => x._id === star.ownedByPlayerId)
   }
 
-  getStarsOwnedByPlayer (player, stars) {
+  getStarsOwnedByPlayer(player, stars) {
+    if (player == null) {
+      return [];
+    }
+
     return stars.filter(s => s.ownedByPlayerId && s.ownedByPlayerId === player._id)
   }
 
@@ -1077,6 +1081,12 @@ class GameHelper {
     const fromEconomy = player.stats.totalEconomy * 10
     const upkeep = this._getUpkeepCosts(game, player);
     return fromEconomy - upkeep  + this._getBankingCredits(game, player);
+  }
+
+  calculateTickIncome(game, player) {
+    let stars = this.getStarsOwnedByPlayer(player, game.galaxy.stars).filter(s => s.specialistId === 12); // Financial Analyst
+
+    return stars.reduce((totalScience, star) => totalScience + star.infrastructure.science, 0) * game.constants.research.sciencePointMultiplier;
   }
 
   isStarHasMultiplePlayersInOrbit (game, star) {

--- a/client/src/views/game/components/inbox/conversations/ConversationTradeEvent.vue
+++ b/client/src/views/game/components/inbox/conversations/ConversationTradeEvent.vue
@@ -29,10 +29,10 @@
             <em>Sent <span class="text-warning">{{event.data.carrierShips}} ships</span>.</em>
         </p>
         <p v-if="event.type === 'playerDebtSettled'" class="mb-1">
-          <em>Paid off <span class="text-warning">{{event.data.amount}} credits</span> of debt.</em>
+          <em>Paid off <span class="text-warning">{{getFormattedDebtValue(event.data.amount)}}</span> of debt.</em>
         </p>
         <p v-if="event.type === 'playerDebtForgiven'" class="mb-1">
-          <em>Forgave <span class="text-warning">{{event.data.amount}} credits</span> of debt.</em>
+          <em>Forgave <span class="text-warning">{{getFormattedDebtValue(event.data.amount)}}</span> of debt.</em>
         </p>
         <p v-if="event.type === 'playerDiplomacyStatusChanged'" class="mb-1">
           <em><strong>Diplomatic status changed</strong>:</em>
@@ -101,6 +101,13 @@ export default {
     },
     getFromPlayerColour () {
       return GameHelper.getPlayerColour(this.$store.state.game, this.getFromPlayer()._id)
+    },
+    getFormattedDebtValue(withText = false) {
+      if (this.event.data.ledgerType === 'credits') {
+        return `$${this.event.data.amount} credits`
+      }
+
+      return `${this.event.data.amount} specialist token(s)`
     }
   },
   computed: {

--- a/client/src/views/game/components/menu/MainBar.vue
+++ b/client/src/views/game/components/menu/MainBar.vue
@@ -96,8 +96,6 @@
       <map-object-selector v-if="menuState == MENU_STATES.MAP_OBJECT_SELECTOR"
         @onCloseRequested="onCloseRequested"
         :mapObjects="menuArguments"
-        @onOpenStarDetailRequested="onOpenStarDetailRequested"
-        @onOpenCarrierDetailRequested="onOpenCarrierDetailRequested"
         @onEditWaypointsRequested="onEditWaypointsRequested"
         @onShipTransferRequested="onShipTransferRequested"
         @onBuildCarrierRequested="onBuildCarrierRequested"/>

--- a/client/src/views/game/components/menu/MapObjectSelector.vue
+++ b/client/src/views/game/components/menu/MapObjectSelector.vue
@@ -170,12 +170,10 @@ export default {
     onViewObjectRequested (mapObject) {
       switch (mapObject.type) {
         case 'star':
-          gameContainer.map.clickStar(mapObject.data._id)
-          this.$emit('onOpenStarDetailRequested', mapObject.data._id)
+          gameContainer.map.clickStar(mapObject.data._id);
           break
         case 'carrier':
-          gameContainer.map.clickCarrier(mapObject.data._id)
-          this.$emit('onOpenCarrierDetailRequested', mapObject.data._id)
+          gameContainer.map.clickCarrier(mapObject.data._id);
           break
       }
     },

--- a/client/src/views/game/components/player/StatisticRow.vue
+++ b/client/src/views/game/components/player/StatisticRow.vue
@@ -1,0 +1,108 @@
+<template>
+    <tr>
+      <td>{{header}}</td>
+      <td class="text-end" :title="(isPlayerStatAlwaysUncertain || isDarkModeExtra) && !isUserPlayer() ? scanningRangeTooltip : null">{{formatValue(player, playerStat)}}{{ !hasPerspective && (isPlayerStatAlwaysUncertain || isDarkModeExtra) && !isUserPlayer() ? '?' : ''}}</td>
+      <td class="text-end" v-if="userIsInGame() && !isUserPlayer()"
+        :class="{'text-danger': playerStat > userPlayerStat,
+                  'text-success': playerStat < userPlayerStat}">{{formatValue(userPlayer, userPlayerStat)}}</td>
+    </tr>
+</template>
+
+<script>
+import GameHelper from '../../../../services/gameHelper'
+
+export default {
+  props: {
+    playerId: {
+      type: String,
+      required: true
+    },
+    header: {
+      type: String,
+      required: true
+    },
+    scanningRangeTooltip: {
+      type: String,
+      required: true
+    },
+    isPlayerStatAlwaysUncertain: {
+      type: Boolean,
+      required: false
+    },
+    playerStat: {
+      type: Number,
+      required: true
+    },
+    userPlayerStat: {
+      type: Number,
+      required: false
+    },
+    formatFunction: {
+      type: Function
+    }
+  },
+  methods: {
+    isUserPlayer () {
+      return this.userPlayer && this.userPlayer._id === this.player._id
+    },
+    getUserPlayer () {
+      return GameHelper.getUserPlayer(this.$store.state.game)
+    },
+    userIsInGame () {
+      return this.userPlayer != null
+    },
+    formatValue(player, value) {
+      if (this.formatFunction != null) {
+        return this.formatFunction(player, value);
+      }
+
+      return value;
+    }
+  },
+  computed: {
+    player () {
+        return GameHelper.getPlayerById(this.$store.state.game, this.playerId)
+    },
+    userPlayer () {
+        return GameHelper.getUserPlayer(this.$store.state.game)
+    },
+    isSpecialistsEnabled () {
+      return GameHelper.isSpecialistsEnabled(this.$store.state.game)
+    },
+    isDarkModeExtra () {
+      return GameHelper.isDarkModeExtra(this.$store.state.game)
+    },
+    isConquestHomeStars () {
+      return GameHelper.isConquestHomeStars(this.$store.state.game)
+    },
+    playerIncome () {
+      return GameHelper.calculateIncome(this.$store.state.game, this.player)
+    },
+    userPlayerIncome () {
+      return GameHelper.calculateIncome(this.$store.state.game, this.userPlayer)
+    },
+    playerTickIncome() {
+      return GameHelper.calculateTickIncome(this.$store.state.game, this.player)
+    },
+    userPlayerTickIncome() {
+      return GameHelper.calculateTickIncome(this.$store.state.game, this.userPlayer)
+    },
+    isDarkModeExtra() {
+      return GameHelper.isDarkModeExtra(this.$store.state.game);
+    },
+    hasPerspective() {
+      if (GameHelper.getUserPlayer(this.$store.state.game)) {
+        return false
+      }
+
+      return this.player.hasPerspective || false;
+    }
+  }
+}
+</script>
+
+<style scoped>
+  td {
+    padding: 0;
+  }
+</style>

--- a/client/src/views/game/components/player/Statistics.vue
+++ b/client/src/views/game/components/player/Statistics.vue
@@ -9,55 +9,61 @@
           </tr>
       </thead>
       <tbody>
-          <tr>
-              <td>Stars</td>
-              <td class="text-end">{{player.stats.totalStars}}</td>
-              <td class="text-end" v-if="userIsInGame() && !isUserPlayer()"
-                :class="{'text-danger': player.stats.totalStars > userPlayer.stats.totalStars,
-                          'text-success': player.stats.totalStars < userPlayer.stats.totalStars}">{{userPlayer.stats.totalStars}}</td>
-          </tr>
-          <tr v-if="isConquestHomeStars">
-              <td>Capitals</td>
-              <td class="text-end">{{player.stats.totalHomeStars}}</td>
-              <td class="text-end" v-if="userIsInGame() && !isUserPlayer()"
-                :class="{'text-danger': player.stats.totalHomeStars > userPlayer.stats.totalHomeStars,
-                          'text-success': player.stats.totalHomeStars < userPlayer.stats.totalHomeStars}">{{userPlayer.stats.totalHomeStars}}</td>
-          </tr>
-          <tr>
-              <td>Carriers</td>
-              <td class="text-end">{{player.stats.totalCarriers}}</td>
-              <td class="text-end" v-if="userIsInGame() && !isUserPlayer()"
-                :class="{'text-danger': player.stats.totalCarriers > userPlayer.stats.totalCarriers,
-                          'text-success': player.stats.totalCarriers < userPlayer.stats.totalCarriers}">{{userPlayer.stats.totalCarriers}}</td>
-          </tr>
-          <tr v-if="isSpecialistsEnabled">
-              <td>Specialists</td>
-              <td class="text-end">{{player.stats.totalSpecialists}}</td>
-              <td class="text-end" v-if="userIsInGame() && !isUserPlayer()"
-                :class="{'text-danger': player.stats.totalSpecialists > userPlayer.stats.totalSpecialists,
-                          'text-success': player.stats.totalSpecialists < userPlayer.stats.totalSpecialists}">{{userPlayer.stats.totalSpecialists}}</td>
-          </tr>
-          <tr>
-              <td>Ships</td>
-              <td class="text-end">{{player.stats.totalShips}}<span v-if="player.stats.totalShipsMax">/{{player.stats.totalShipsMax}}</span></td>
-              <td class="text-end" v-if="userIsInGame() && !isUserPlayer()"
-                :class="{'text-danger': player.stats.totalShips > userPlayer.stats.totalShips,
-                          'text-success': player.stats.totalShips < userPlayer.stats.totalShips}">{{userPlayer.stats.totalShips}}<span v-if="userPlayer.stats.totalShipsMax">/{{userPlayer.stats.totalShipsMax}}</span></td>
-          </tr>
-          <tr>
-              <td>New Ships</td>
-              <td class="text-end">{{player.stats.newShips}}</td>
-              <td class="text-end" v-if="userIsInGame() && !isUserPlayer()"
-                :class="{'text-danger': player.stats.newShips > userPlayer.stats.newShips,
-                          'text-success': player.stats.newShips < userPlayer.stats.newShips}">{{userPlayer.stats.newShips}}</td>
-          </tr>
-          <tr>
-            <td>Cycle Income</td>
-            <td class="text-end">${{playerIncome}}</td>
-            <td class="text-end" v-if="userIsInGame() && !isUserPlayer()"
-              :class="{'text-danger': playerIncome > userPlayerIncome,
-                        'text-success': playerIncome < userPlayerIncome}">${{userPlayerIncome}}</td>
-          </tr>
+          <statistic-row :playerId="playerId"
+                         header="Stars"
+                         scanningRangeTooltip="This figure is based on the stars in your scanning range."
+                         :playerStat="player.stats.totalStars"
+                         :userPlayerStat="userPlayer?.stats.totalStars">
+          </statistic-row>
+          <statistic-row v-if="isConquestHomeStars"
+                         :playerId="playerId"
+                         header="Capitals"
+                         scanningRangeTooltip="This figure is based on the capitals in your scanning range."
+                         :playerStat="player.stats.totalHomeStars"
+                         :userPlayerStat="userPlayer?.stats.totalHomeStars">
+          </statistic-row>
+          <statistic-row :playerId="playerId"
+                         header="Carriers"
+                         scanningRangeTooltip="This figure is based on the carriers in your scanning range."
+                         :playerStat="player.stats.totalCarriers"
+                         :userPlayerStat="userPlayer?.stats.totalCarriers">
+          </statistic-row>
+          <statistic-row  v-if="isSpecialistsEnabled"
+                         :playerId="playerId"
+                         header="Specialists"
+                         scanningRangeTooltip="This figure is based on the specialists in your scanning range."
+                         :playerStat="player.stats.totalSpecialists"
+                         :userPlayerStat="userPlayer?.stats.totalSpecialists">
+          </statistic-row>
+          <statistic-row :playerId="playerId"
+                         header="Ships"
+                         scanningRangeTooltip="This figure is based on the ships in your scanning range."
+                         :playerStat="player.stats.totalShips"
+                         :userPlayerStat="userPlayer?.stats.totalShips"
+                         :formatFunction="formatTotalShipsValue">
+          </statistic-row>
+          <statistic-row :playerId="playerId"
+                         header="New Ships"
+                         scanningRangeTooltip="This figure is based on the stars in your scanning range."
+                         :playerStat="player.stats.newShips"
+                         :userPlayerStat="userPlayer?.stats.newShips">
+          </statistic-row>
+          <statistic-row :playerId="playerId"
+                         header="Cycle Income"
+                         scanningRangeTooltip="This figure is based on the stars in your scanning range."
+                         :playerStat="playerIncome"
+                         :userPlayerStat="userPlayerIncome"
+                         :formatFunction="formatCreditsValue">
+          </statistic-row>
+          <statistic-row v-if="playerTickIncome > 0 || userPlayerTickIncome > 0"
+                         :playerId="playerId"
+                         header="Tick Income"
+                         scanningRangeTooltip="This figure is based on the Financial Analysts in your scanning range."
+                         :playerStat="playerTickIncome"
+                         :userPlayerStat="userPlayerTickIncome"
+                         :formatFunction="formatCreditsValue"
+                         :isPlayerStatAlwaysUncertain="true">
+          </statistic-row>
       </tbody>
   </table>
 
@@ -67,8 +73,12 @@
 
 <script>
 import GameHelper from '../../../../services/gameHelper'
+import StatisticRow from './StatisticRow'
 
 export default {
+  components: {
+    'statistic-row': StatisticRow,
+  },
   props: {
     playerId: String
   },
@@ -81,6 +91,16 @@ export default {
     },
     userIsInGame () {
       return this.userPlayer != null
+    },
+    formatCreditsValue: function (player, value) {
+      return `$${value}`;
+    },
+    formatTotalShipsValue: function (player, value) {
+      if (player.stats.totalShipsMax != null) {
+        return `${value}/${player.stats.totalShipsMax}`
+      }
+
+      return value;
     }
   },
   computed: {
@@ -103,14 +123,23 @@ export default {
       return GameHelper.calculateIncome(this.$store.state.game, this.player)
     },
     userPlayerIncome () {
-      return GameHelper.calculateIncome(this.$store.state.game, this.userPlayer)
+      return this.userPlayer != null ? GameHelper.calculateIncome(this.$store.state.game, this.userPlayer) : null
+    },
+    playerTickIncome() {
+      return GameHelper.calculateTickIncome(this.$store.state.game, this.player)
+    },
+    userPlayerTickIncome() {
+      return this.userPlayer != null ? GameHelper.calculateTickIncome(this.$store.state.game, this.userPlayer) : null;
+    },
+    isDarkModeExtra() {
+      return GameHelper.isDarkModeExtra(this.$store.state.game);
     }
   }
 }
 </script>
 
 <style scoped>
-.table-sm td, .table-sm th {
+.table-sm th {
   padding: 0;
 }
 </style>


### PR DESCRIPTION
* Added new StatisticRow component to consolidate statistic row functionality and reduce template duplication.
* Updated statistic rows to show a question mark and tooltip if the stat is based on the player's scanning range.
* Added new Tick Income statistic row, which is shown if there are any financial analysts in the player's scanning range.
* Added calculateTickIncome() method to gameHelper.js.
* Updated getStarsOwnedByPlayer() to return an empty array if the player parameter value was null or undefined.
* Fixed token debt forgiveness between two players being displayed as tokens in the in-game chat between those players.
* Hopefully fixed the issue that would cause tapping on a carrier/star on the galaxy map on mobile to also send an additional tap event through to whatever modal that would open up afterwards (resulting in accidental infrastructure acquisition, etc).
    - Updated onClicked() method in carrier.js and star.js to run in a setTimeout() to allow the click/tap event to be fully processed before we'll have shown any modals that may result from that tap event.  This prevents the tap event that opened the modal also being picked up as a new tap event on that modal.
    - Updated onViewObjectRequested() method in MapObjectSelector component to not emit onOpenStarDetailRequested or onOpenCarrierDetailRequested.  These would be handled in the MainBar component, and ultimately lead to a call to store.commit() for MENU_STATES.STAR_DETAIL or MENU_STATES.CARRIER_DETAIL.  However, store.commit() for these menu states is also ultimately called as part of the map.clickStar() or map.clickCarrier() calls, meaning that (now that the click is deferred), the requested detail would open and then immediately close.
    - Updated onStarClicked() and onCarrierClicked() methods in map.js to support an additional property on the dic parameter for tryMultiSelect, to allow for programmatically selecting a carrier orbiting a star without it opening the star detail panel.
    - Updated onCarrierClicked() method in map.js to remove the orbiting check for a carrier, where it would select the star if you clicked on the carrier when it was orbiting a star, because we do actually want to open the carrier detail panel.