### PR TITLE
Capital Star Elimination check fix

### DIFF
--- a/server/services/gameType.ts
+++ b/server/services/gameType.ts
@@ -117,6 +117,6 @@ export default class GameTypeService {
     }
 
     isCapitalStarEliminationMode(game: Game) {
-        return this.isConquestMode(game) && game.settings.conquest.capitalStarElimination === 'enabled';
+        return game.settings.conquest.capitalStarElimination === 'enabled';
     }
 }


### PR DESCRIPTION
* Updated isCapitalStarEliminationMode() method in GameTypeService to not check if the game mode is conquest when checking if capital star elimination is enabled.