### PR TITLE
Ship transfer fixes

### DIFF
--- a/server/services/shipTransfer.ts
+++ b/server/services/shipTransfer.ts
@@ -212,6 +212,10 @@ export default class ShipTransferService {
             throw new ValidationError('The number of carrier ships in the transfer must be 0 or greater.');
         }
 
+        if (carrierShips !== parseInt(carrierShips.toString()) || starShips !== parseInt(starShips.toString())) {
+            throw new ValidationError('The number of ships in the transfer must be a whole number.');
+        }
+
         carrier.ships = carrierShips;
 
         let shipsFraction = star.shipsActual! - star.ships!; // Keep hold of the fractional amount of ships so we can add it back later.

--- a/server/services/types/CarrierWaypoint.ts
+++ b/server/services/types/CarrierWaypoint.ts
@@ -1,6 +1,8 @@
 import { DBObjectId } from "./DBObjectId";
 
-export type CarrierWaypointActionType = 'nothing'|'collectAll'|'dropAll'|'collect'|'drop'|'collectAllBut'|'dropAllBut'|'dropPercentage'|'collectPercentage'|'garrison';
+export const CarrierWaypointActionTypes = ['nothing', 'collectAll', 'dropAll', 'collect', 'drop', 'collectAllBut', 'dropAllBut', 'dropPercentage', 'collectPercentage', 'garrison'] as const;
+
+export type CarrierWaypointActionType = typeof CarrierWaypointActionTypes[number];
 
 export interface CarrierWaypointBase {
     source: DBObjectId;

--- a/server/services/waypoint.ts
+++ b/server/services/waypoint.ts
@@ -2,7 +2,7 @@ import { DBObjectId } from './types/DBObjectId';
 import ValidationError from '../errors/validation';
 import Repository from './repository';
 import { Carrier } from './types/Carrier';
-import { CarrierWaypoint, CarrierWaypointActionType, CarrierWaypointBase } from './types/CarrierWaypoint';
+import { CarrierWaypoint, CarrierWaypointActionType, CarrierWaypointActionTypes, CarrierWaypointBase } from './types/CarrierWaypoint';
 import { Game } from './types/Game';
 import { Player } from './types/Player';
 import { Star } from './types/Star';
@@ -124,8 +124,20 @@ export default class WaypointService {
             waypoint.actionShips = waypoint.actionShips || 0;
             waypoint.action = waypoint.action || 'nothing';
 
-            if (waypoint.actionShips == null || (waypoint.actionShips as any) == '' || +waypoint.actionShips < 0) {
+            if (!Array.from(CarrierWaypointActionTypes).includes(waypoint.action)) {
+                throw new ValidationError(`The specified waypoint action of '${waypoint.action}' is invalid.`);
+            }
+
+            if (waypoint.actionShips == null || (waypoint.actionShips as any) == '') {
                 waypoint.actionShips = 0;
+            }
+
+            if (+waypoint.actionShips < 0) {
+                throw new ValidationError(`The waypoint action ships cannot be less than 0.`);
+            }
+
+            if (+waypoint.actionShips !== parseInt(waypoint.actionShips.toString())) {
+                throw new ValidationError(`The waypoint action ships value must be a whole number.`);
             }
 
             // Make damn sure there is a delay ticks defined.


### PR DESCRIPTION
* Updated transfer() method in ShipTransferService to add validation preventing fractional ship transfers.

* Updated saveWaypointsForCarrier() method in WaypointService:
    - Added validation to prevent invalid carrier actions from being specified.
    - Updated less than 0 check to throw a ValidationError (instead of silently setting actionShips to 0).
    - Added validation to prevent fractional ship carrier actions.