### PR TITLE
gridHelper fix for Vue3

### DIFF
--- a/client/src/services/gridHelper.js
+++ b/client/src/services/gridHelper.js
@@ -11,7 +11,7 @@ class GridHelper {
 
   dynamicSort(data, sortInfo, missingPropertyFallbackFunc) {
     if (sortInfo?.propertyPaths != null) {
-      data = data.sort((a, b) => this.dynamicCompare(a, b, sortInfo, missingPropertyFallbackFunc));
+      data = [...data].sort((a, b) => this.dynamicCompare(a, b, sortInfo, missingPropertyFallbackFunc));
     }
 
     return data;


### PR DESCRIPTION
* Fixed dynamicSort() method in gridHelper mutating the original array.  In Vue3 this results in the sort not being detected.