### PR TITLE
Improve performance of getting stars by id via binary searches

### DIFF
--- a/server/services/carrierMovement.ts
+++ b/server/services/carrierMovement.ts
@@ -158,8 +158,8 @@ export default class CarrierMovementService {
         if (this.isLaunching(carrierInTransit)) {
             const sourceStarId = carrierInTransit.orbiting!;
             const destinationStarId = waypoint.destination;
-            const sourceStar = game.galaxy.stars.find(s => s._id.toString() === sourceStarId.toString())!;
-            const destinationStar = game.galaxy.stars.find(s => s._id.toString() === destinationStarId.toString())!;
+            const sourceStar = this.starService.getByIdBS(game, sourceStarId);
+            const destinationStar = this.starService.getByIdBS(game, destinationStarId);
 
             if (!sourceStar || !destinationStar) {
                 carrierInTransit.waypoints = [];
@@ -185,8 +185,8 @@ export default class CarrierMovementService {
             }
         }
 
-        const sourceStar = game.galaxy.stars.find(s => s._id.toString() === waypoint.source.toString())!;
-        const destinationStar = game.galaxy.stars.find(s => s._id.toString() === waypoint.destination.toString())!;
+        const sourceStar = this.starService.getByIdBS(game, waypoint.source);
+        const destinationStar = this.starService.getByIdBS(game, waypoint.destination);
         const carrierOwner = game.galaxy.players.find(p => p._id.toString() === carrierInTransit.ownedByPlayerId!.toString())!;
         const warpSpeed = this.canTravelAtWarpSpeed(game, carrierOwner, carrierInTransit, sourceStar, destinationStar);
         const instantSpeed = this.starService.isStarPairWormHole(sourceStar, destinationStar);
@@ -222,8 +222,8 @@ export default class CarrierMovementService {
 
     getNextLocationToWaypoint(game: Game, carrier: Carrier) {
         let waypoint = carrier.waypoints[0];
-        let sourceStar = game.galaxy.stars.find(s => s._id.toString() === waypoint.source.toString())!;
-        let destinationStar = game.galaxy.stars.find(s => s._id.toString() === waypoint.destination.toString())!;
+        let sourceStar = this.starService.getByIdBS(game, waypoint.source);
+        let destinationStar = this.starService.getByIdBS(game, waypoint.destination);
         let carrierOwner = game.galaxy.players.find(p => p._id.toString() === carrier.ownedByPlayerId!.toString())!;
 
         let warpSpeed = false;
@@ -359,7 +359,7 @@ export default class CarrierMovementService {
         // If the carrier has a waypoint then check if the
         // current destination exists.
         if (carrier.waypoints.length) {
-            return game.galaxy.stars.find(s => s._id.toString() === carrier.waypoints[0].destination.toString()) == null;
+            return this.starService.getByIdBS(game, carrier.waypoints[0].destination) == null;
         }
 
         // If there are no waypoints and they are in transit then must be lost, otherwise all good.

--- a/server/services/gameGalaxy.ts
+++ b/server/services/gameGalaxy.ts
@@ -250,7 +250,7 @@ export default class GameGalaxyService {
             const homeStarId = player.homeStarId?.toString();
 
             if (homeStarId) {
-                const homeStar = game.galaxy.stars.find(s => s._id.toString() === homeStarId);
+                const homeStar = this.starService.getByIdBS(game, homeStarId);
                 if (!homeStar?.isInScanningRange) {
                     delete player.homeStarId;
                 }
@@ -433,7 +433,7 @@ export default class GameGalaxyService {
                 }
 
                 // Ignore stars the player owns, they will always be visible.
-                let isOwnedByCurrentPlayer = playerStars.find(y => y._id.toString() === s._id.toString());
+                let isOwnedByCurrentPlayer = this.starService.getByIdBSForStars(playerStars, s._id);
 
                 if (isOwnedByCurrentPlayer) {
                     // Calculate infrastructure upgrades for the star.

--- a/server/services/player.ts
+++ b/server/services/player.ts
@@ -525,7 +525,7 @@ export default class PlayerService extends EventEmitter {
     ownsOriginalHomeStar(game: Game, player: Player) {
         const stars = this.starService.listStarsOwnedByPlayer(game.galaxy.stars, player._id);
 
-        return stars.find(s => s._id.toString() === player.homeStarId!.toString()) != null;
+        return this.starService.getByIdBSForStars(stars, player.homeStarId!) != null;
     }
 
     canSlotBeOpen(game: Game, player: Player) {

--- a/server/services/star.ts
+++ b/server/services/star.ts
@@ -125,12 +125,16 @@ export default class StarService extends EventEmitter {
     }
 
     getByIdBS(game: Game, id: DBObjectId | string) {
+        return this.getByIdBSForStars<Star>(game.galaxy.stars, id);
+    }
+
+    getByIdBSForStars<T extends { _id: DBObjectId | string }>(stars: T[], id: DBObjectId | string): T  {
         let start = 0;
-        let end = game.galaxy.stars.length - 1;
+        let end = stars.length - 1;
 
         while (start <= end) {
             let middle = Math.floor((start + end) / 2);
-            let star = game.galaxy.stars[middle];
+            let star = stars[middle];
 
             if (star._id.toString() === id.toString()) {
                 // found the id
@@ -146,7 +150,7 @@ export default class StarService extends EventEmitter {
 
         // id wasn't found
         // Return the old way
-        return game.galaxy.stars.find(s => s._id.toString() === id.toString())!;
+        return stars.find(s => s._id.toString() === id.toString())!;
     }
 
     setupHomeStar(game: Game, homeStar: Star, player: Player, gameSettings: GameSettings) {
@@ -322,7 +326,7 @@ export default class StarService extends EventEmitter {
             let starIds = this.getStarsWithinScanningRangeOfStarByStarIds(game, star, starsToCheck);
 
             for (let starId of starIds) {
-                if (starsInRange.find(x => x._id.toString() === starId._id.toString()) == null) {
+                if (this.getByIdBSForStars(starsInRange, starId._id) == null) {
                     starsInRange.push(starId);
                     starsToCheck.splice(starsToCheck.indexOf(starId), 1);
                 }
@@ -347,7 +351,7 @@ export default class StarService extends EventEmitter {
                 });
                 
             for (let wormHoleStar of wormHoleStars) {
-                if (starsInRange.find(s => s._id.toString() === wormHoleStar.destination._id.toString()) == null) {
+                if (this.getByIdBSForStars(starsInRange, wormHoleStar.destination._id) == null) {
                     starsInRange.push({
                         _id: wormHoleStar.destination._id,
                         location: wormHoleStar.destination.location,

--- a/server/services/waypoint.ts
+++ b/server/services/waypoint.ts
@@ -672,7 +672,7 @@ export default class WaypointService {
             let waypoint = carrier.waypoints[i];
 
             // If the destination is not within scanning range of the player, remove it and all subsequent waypoints.
-            let inRange = ownerScannedStars.find(s => s._id.toString() === waypoint.destination.toString()) != null;
+            let inRange = this.starService.getByIdBSForStars(ownerScannedStars, waypoint.destination) != null
 
             if (!inRange) {
                 carrier.waypoints.splice(i);


### PR DESCRIPTION
Refactored server code game tick logic (and other places) where we use `.find(...)` to get a star by ID to instead use the binary search algorithm logic.