### PR TITLE
Makes it so stars are not unnecessarily fetched when they are known

### DIFF
--- a/server/services/waypoint.ts
+++ b/server/services/waypoint.ts
@@ -641,18 +641,20 @@ export default class WaypointService {
     }
 
     sanitiseAllCarrierWaypointsByScanningRange(game: Game) {
-        const scanningRanges = game.galaxy.players
-            .map(p => {
-                return {
+        const scanningRanges = new Map<string, { player: Player, stars: Star[] }>();
+
+        game.galaxy.players
+            .forEach(p => {
+                scanningRanges.set(p._id.toString(), {
                     player: p,
                     stars: this.starService.filterStarsByScanningRange(game, [p]).sort((a, b) => a._id.toString() < b._id.toString() ? -1 : 1)
-                }
+                });
             });
-
+        
         game.galaxy.carriers
             .filter(c => c.waypoints.length)
             .map(c => {
-                let scanningRangePlayer = scanningRanges.find(s => s.player._id.toString() === c.ownedByPlayerId!.toString())!;
+                let scanningRangePlayer = scanningRanges.get(c.ownedByPlayerId!.toString())!;
 
                 return {
                     carrier: c,

--- a/server/spec/star.spec.ts
+++ b/server/spec/star.spec.ts
@@ -45,6 +45,31 @@ const game = {
     }
 };
 
+const fakeStarList = [
+    { _id: 'aabbcc'},
+    { _id: 'bbccdd'},
+    { _id: 'ccddee'},
+]
+
+
+
+let fakeMapObjects = [
+    {
+        _id: 'aabbcc',
+        location: {
+            x: 0,
+            y: 0
+        }
+    },
+    {
+        _id: 'bbccdd',
+        location: {
+            x: 0,
+            y: 0
+        }
+    }
+]
+
 describe('star', () => {
 
     let starService;
@@ -142,5 +167,34 @@ describe('star', () => {
         expect(homeStar.infrastructure.industry).toEqual(gameSettings.player.startingInfrastructure.industry);
         expect(homeStar.infrastructure.science).toEqual(gameSettings.player.startingInfrastructure.science);
     });
+
+    it('should find the index of a star in a sorted array', () => {
+        expect(starService._binarySearchIndex(fakeStarList, 'aabbcc')).toEqual(0);
+        expect(starService._binarySearchIndex(fakeStarList, 'bbccdd')).toEqual(1);
+        expect(starService._binarySearchIndex(fakeStarList, 'ccddee')).toEqual(2);
+        expect(starService._binarySearchIndex(fakeStarList, 'dddeee')).toEqual(3);
+    });
+
+    it('should find the index where a star should be in but not in the array', () => {
+        expect(starService._binarySearchIndex(fakeStarList, 'eeeeee')).toEqual(3);
+        expect(starService._binarySearchIndex(fakeStarList, 'abcs')).toEqual(1);
+    });
     
+    it('should find the star in a array', () => {
+        expect(starService.binarySearchStars(fakeStarList, 'aabbcc')).toEqual(fakeStarList[0]);
+        expect(starService.binarySearchStars(fakeStarList, 'ccddee')).toEqual(fakeStarList[2]);
+        expect(starService.binarySearchStars(fakeStarList, 'eeeeee')).toEqual(undefined);
+    })
+
+    it('should insert new map object into a sorted array', () => {
+        const mapObject = {
+            _id: 'abcd',
+            location: {
+                x: 0,
+                y: 0
+            }
+        };
+        starService._insertIntoSortedMapObjectsArray(fakeMapObjects, mapObject);
+        expect(starService._binarySearchIndex(fakeMapObjects, 'abcd')).toEqual(1);
+    });
 });


### PR DESCRIPTION
What I found is that in the Waypoint  Service the function `_waypointRouteIsWithinHyperspaceRange` was being used in contexts where either one or both stars in the waypoint could be fetched or have already been fetched in the case of `saveWaypointsForCarrier` the usage searches for both stars in the waypoint before calling the within hyperspace range function (which also redoes the search for both stars).
![image](https://github.com/user-attachments/assets/e50884a8-8b16-4f35-b221-52440cfc92bc)

for `cullWaypointsByHyperspaceRange` since we are going through a list of waypoints the source star for each iteration could be searched up to 2 times. I have modified this function to have variables for source and destination star. Doing this we can reduce the required searches in half - 1. Pulling the initial star and only grabbing the next destination star for each iteration.

Since I have replaced all usage of `_waypointRouteIsWithinHyperspaceRange` I have removed it.

# Binary Search Update
I have moved the binary search out of `getByIdBSForStars` into its own function `binarySearchStars` and updated `getByIdBSForStars` to use the new function for binary search retaining its original functionality.

The Dark Mode carrier sanitize tick step was taking a large amount of time to complete and upon inspection its likely that replacing find with the double search may take up extra time. In `filterStarsByScanningRange` which is a function used by dark mode carrier sanitize I have made it so that it operates on a sorted list and any mutation to that list remains sorted, which is required in order to use binary search. this with changes around it should hopefully reduce the time on that tick step.

I have also added new tests to ensure the changes I made with Binary Searching is still compatible