### PR TITLE
Rounds Capture Reward Limit

### DIFF
--- a/server/services/starCapture.ts
+++ b/server/services/starCapture.ts
@@ -172,7 +172,7 @@ export default class StarCaptureService {
             const effectiveTechs = this.technologyService.getStarEffectiveTechnologyLevels(game, star);
 
             const starEconCost = this._calculateEconomyCostSum(game, starEconomy, this.starService.calculateTerraformedResource(star.naturalResources.economy, effectiveTechs.terraforming));
-            const rewardLimit = starEconCost * game.constants.star.captureRewardLimitMultiplier;
+            const rewardLimit = Math.floor(starEconCost * game.constants.star.captureRewardLimitMultiplier);
 
             return Math.min(finalReward, rewardLimit);
         }


### PR DESCRIPTION
Fixes an issue where the capture reward limit would result in non-integer amounts due to me missing a round, this should resolve that