### PR TITLE
Adds researchCostProgression to game settings that were missing it

### DIFF
--- a/client/src/config/gamesettings/1v1.json
+++ b/client/src/config/gamesettings/1v1.json
@@ -91,30 +91,34 @@
     "globalEvents": "disabled"
   },
   "technology": {
-    "startingTechnologyLevel": {
-      "terraforming": 1,
-      "experimentation": 0,
-      "scanning": 2,
-      "hyperspace": 1,
-      "manufacturing": 1,
-      "banking": 1,
-      "weapons": 5,
-      "specialists": 3
-    },
-    "researchCosts": {
-      "terraforming": "standard",
-      "experimentation": "none",
-      "scanning": "standard",
-      "hyperspace": "standard",
-      "manufacturing": "expensive",
-      "banking": "cheap",
-      "weapons": "none",
-      "specialists": "standard"
-    },
-    "experimentationDistribution": "random",
-    "bankingReward": "standard",
-    "experimentationReward": "standard",
-    "specialistTokenReward": "standard"
+      "startingTechnologyLevel": {
+          "terraforming": 1,
+          "experimentation": 0,
+          "scanning": 2,
+          "hyperspace": 1,
+          "manufacturing": 1,
+          "banking": 1,
+          "weapons": 5,
+          "specialists": 3
+      },
+      "researchCosts": {
+          "terraforming": "standard",
+          "experimentation": "none",
+          "scanning": "standard",
+          "hyperspace": "standard",
+          "manufacturing": "expensive",
+          "banking": "cheap",
+          "weapons": "none",
+          "specialists": "standard"
+      },
+      "researchCostProgression": {
+          "progression": "standard",
+          "growthFactor": "medium"
+      },
+      "experimentationDistribution": "random",
+      "bankingReward": "standard",
+      "experimentationReward": "standard",
+      "specialistTokenReward": "standard"
   },
   "gameTime": {
     "gameType": "realTime",

--- a/client/src/config/gamesettings/1v1turnBased.json
+++ b/client/src/config/gamesettings/1v1turnBased.json
@@ -45,10 +45,7 @@
         "carrierSpeed": 10,
         "starCaptureReward": "enabled",
         "specialistBans": {
-            "star": [
-                16,
-                17
-            ],
+            "star": [16, 17],
             "carrier": []
         }
     },
@@ -113,6 +110,10 @@
             "banking": "cheap",
             "weapons": "none",
             "specialists": "standard"
+        },
+        "researchCostProgression": {
+            "progression": "standard",
+            "growthFactor": "medium"
         },
         "experimentationDistribution": "random",
         "bankingReward": "standard",

--- a/client/src/config/gamesettings/32player_ultradark.json
+++ b/client/src/config/gamesettings/32player_ultradark.json
@@ -47,10 +47,7 @@
         "carrierSpeed": 20,
         "starCaptureReward": "enabled",
         "specialistBans": {
-            "star": [
-                16,
-                17
-            ],
+            "star": [16, 17],
             "carrier": []
         }
     },
@@ -115,6 +112,10 @@
             "banking": "standard",
             "weapons": "standard",
             "specialists": "standard"
+        },
+        "researchCostProgression": {
+            "progression": "standard",
+            "growthFactor": "medium"
         },
         "experimentationDistribution": "random",
         "bankingReward": "standard",

--- a/client/src/config/gamesettings/newPlayer.json
+++ b/client/src/config/gamesettings/newPlayer.json
@@ -46,10 +46,7 @@
         "carrierSpeed": 10,
         "starCaptureReward": "enabled",
         "specialistBans": {
-            "star": [
-                16,
-                17
-            ],
+            "star": [16, 17],
             "carrier": []
         }
     },
@@ -114,6 +111,10 @@
             "banking": "standard",
             "weapons": "standard",
             "specialists": "standard"
+        },
+        "researchCostProgression": {
+            "progression": "standard",
+            "growthFactor": "medium"
         },
         "experimentationDistribution": "random",
         "bankingReward": "standard",

--- a/client/src/config/gamesettings/special_anonymous.json
+++ b/client/src/config/gamesettings/special_anonymous.json
@@ -48,10 +48,7 @@
         "carrierSpeed": 15,
         "starCaptureReward": "enabled",
         "specialistBans": {
-            "star": [
-                16,
-                17
-            ],
+            "star": [16, 17],
             "carrier": []
         }
     },
@@ -116,6 +113,10 @@
             "banking": "standard",
             "weapons": "standard",
             "specialists": "standard"
+        },
+        "researchCostProgression": {
+            "progression": "standard",
+            "growthFactor": "medium"
         },
         "experimentationDistribution": "random",
         "bankingReward": "standard",

--- a/client/src/config/gamesettings/special_arcade.json
+++ b/client/src/config/gamesettings/special_arcade.json
@@ -47,9 +47,7 @@
         "carrierSpeed": 20,
         "starCaptureReward": "disabled",
         "specialistBans": {
-            "star": [
-                9
-            ],
+            "star": [9],
             "carrier": []
         }
     },
@@ -117,6 +115,10 @@
             "banking": "standard",
             "weapons": "standard",
             "specialists": "none"
+        },
+        "researchCostProgression": {
+            "progression": "standard",
+            "growthFactor": "medium"
         },
         "experimentationDistribution": "random",
         "bankingReward": "standard",

--- a/client/src/config/gamesettings/special_battleRoyale.json
+++ b/client/src/config/gamesettings/special_battleRoyale.json
@@ -47,10 +47,7 @@
         "carrierSpeed": 15,
         "starCaptureReward": "enabled",
         "specialistBans": {
-            "star": [
-                16,
-                17
-            ],
+            "star": [16, 17],
             "carrier": []
         }
     },
@@ -115,6 +112,10 @@
             "banking": "standard",
             "weapons": "standard",
             "specialists": "standard"
+        },
+        "researchCostProgression": {
+            "progression": "standard",
+            "growthFactor": "medium"
         },
         "experimentationDistribution": "random",
         "bankingReward": "standard",

--- a/client/src/config/gamesettings/special_dark.json
+++ b/client/src/config/gamesettings/special_dark.json
@@ -47,10 +47,7 @@
         "carrierSpeed": 15,
         "starCaptureReward": "enabled",
         "specialistBans": {
-            "star": [
-                16,
-                17
-            ],
+            "star": [16, 17],
             "carrier": []
         }
     },
@@ -115,6 +112,10 @@
             "banking": "standard",
             "weapons": "standard",
             "specialists": "standard"
+        },
+        "researchCostProgression": {
+            "progression": "standard",
+            "growthFactor": "medium"
         },
         "experimentationDistribution": "random",
         "bankingReward": "standard",

--- a/client/src/config/gamesettings/special_fog.json
+++ b/client/src/config/gamesettings/special_fog.json
@@ -47,10 +47,7 @@
         "carrierSpeed": 15,
         "starCaptureReward": "enabled",
         "specialistBans": {
-            "star": [
-                16,
-                17
-            ],
+            "star": [16, 17],
             "carrier": []
         }
     },
@@ -115,6 +112,10 @@
             "banking": "standard",
             "weapons": "standard",
             "specialists": "standard"
+        },
+        "researchCostProgression": {
+            "progression": "standard",
+            "growthFactor": "medium"
         },
         "experimentationDistribution": "random",
         "bankingReward": "standard",

--- a/client/src/config/gamesettings/special_freeForAll.json
+++ b/client/src/config/gamesettings/special_freeForAll.json
@@ -47,10 +47,7 @@
         "carrierSpeed": 15,
         "starCaptureReward": "enabled",
         "specialistBans": {
-            "star": [
-                16,
-                17
-            ],
+            "star": [16, 17],
             "carrier": []
         }
     },
@@ -115,6 +112,10 @@
             "banking": "standard",
             "weapons": "standard",
             "specialists": "standard"
+        },
+        "researchCostProgression": {
+            "progression": "standard",
+            "growthFactor": "medium"
         },
         "experimentationDistribution": "random",
         "bankingReward": "standard",

--- a/client/src/config/gamesettings/special_homeStar.json
+++ b/client/src/config/gamesettings/special_homeStar.json
@@ -47,10 +47,7 @@
         "carrierSpeed": 15,
         "starCaptureReward": "enabled",
         "specialistBans": {
-            "star": [
-                16,
-                17
-            ],
+            "star": [16, 17],
             "carrier": []
         }
     },
@@ -115,6 +112,10 @@
             "banking": "standard",
             "weapons": "standard",
             "specialists": "standard"
+        },
+        "researchCostProgression": {
+            "progression": "standard",
+            "growthFactor": "medium"
         },
         "experimentationDistribution": "random",
         "bankingReward": "standard",

--- a/client/src/config/gamesettings/special_homeStarElimination.json
+++ b/client/src/config/gamesettings/special_homeStarElimination.json
@@ -47,10 +47,7 @@
         "carrierSpeed": 15,
         "starCaptureReward": "enabled",
         "specialistBans": {
-            "star": [
-                16,
-                17
-            ],
+            "star": [16, 17],
             "carrier": []
         }
     },
@@ -115,6 +112,10 @@
             "banking": "standard",
             "weapons": "standard",
             "specialists": "standard"
+        },
+        "researchCostProgression": {
+            "progression": "standard",
+            "growthFactor": "medium"
         },
         "experimentationDistribution": "random",
         "bankingReward": "standard",

--- a/client/src/config/gamesettings/special_kingOfTheHill.json
+++ b/client/src/config/gamesettings/special_kingOfTheHill.json
@@ -47,10 +47,7 @@
         "carrierSpeed": 15,
         "starCaptureReward": "enabled",
         "specialistBans": {
-            "star": [
-                16,
-                17
-            ],
+            "star": [16, 17],
             "carrier": []
         }
     },
@@ -115,6 +112,10 @@
             "banking": "standard",
             "weapons": "standard",
             "specialists": "standard"
+        },
+        "researchCostProgression": {
+            "progression": "standard",
+            "growthFactor": "medium"
         },
         "experimentationDistribution": "random",
         "bankingReward": "standard",

--- a/client/src/config/gamesettings/special_orbital.json
+++ b/client/src/config/gamesettings/special_orbital.json
@@ -47,10 +47,7 @@
         "carrierSpeed": 15,
         "starCaptureReward": "enabled",
         "specialistBans": {
-            "star": [
-                16,
-                17
-            ],
+            "star": [16, 17],
             "carrier": []
         }
     },
@@ -115,6 +112,10 @@
             "banking": "standard",
             "weapons": "standard",
             "specialists": "standard"
+        },
+        "researchCostProgression": {
+            "progression": "standard",
+            "growthFactor": "medium"
         },
         "experimentationDistribution": "random",
         "bankingReward": "standard",

--- a/client/src/config/gamesettings/special_tinyGalaxy.json
+++ b/client/src/config/gamesettings/special_tinyGalaxy.json
@@ -47,10 +47,7 @@
         "carrierSpeed": 15,
         "starCaptureReward": "enabled",
         "specialistBans": {
-            "star": [
-                16,
-                17
-            ],
+            "star": [16, 17],
             "carrier": []
         }
     },
@@ -115,6 +112,10 @@
             "banking": "standard",
             "weapons": "none",
             "specialists": "standard"
+        },
+        "researchCostProgression": {
+            "progression": "standard",
+            "growthFactor": "medium"
         },
         "experimentationDistribution": "random",
         "bankingReward": "standard",

--- a/client/src/config/gamesettings/special_ultraDark.json
+++ b/client/src/config/gamesettings/special_ultraDark.json
@@ -47,10 +47,7 @@
         "carrierSpeed": 15,
         "starCaptureReward": "enabled",
         "specialistBans": {
-            "star": [
-                16,
-                17
-            ],
+            "star": [16, 17],
             "carrier": []
         }
     },
@@ -115,6 +112,10 @@
             "banking": "standard",
             "weapons": "standard",
             "specialists": "standard"
+        },
+        "researchCostProgression": {
+            "progression": "standard",
+            "growthFactor": "medium"
         },
         "experimentationDistribution": "random",
         "bankingReward": "standard",

--- a/client/src/config/gamesettings/turnBased.json
+++ b/client/src/config/gamesettings/turnBased.json
@@ -46,10 +46,7 @@
         "carrierSpeed": 10,
         "starCaptureReward": "enabled",
         "specialistBans": {
-            "star": [
-                16,
-                17
-            ],
+            "star": [16, 17],
             "carrier": []
         }
     },
@@ -114,6 +111,10 @@
             "banking": "standard",
             "weapons": "standard",
             "specialists": "standard"
+        },
+        "researchCostProgression": {
+            "progression": "standard",
+            "growthFactor": "medium"
         },
         "experimentationDistribution": "random",
         "bankingReward": "standard",


### PR DESCRIPTION
on most game settings files for the preset game settings didn't have `researchCostProgression ` defined, which causes the `Technology Settings` section to break because `researchCostProgression` was defined by no inner members were defined.

Please review that I got all of them right, from what I can tell the ones that were missing it probably stuck with the default settings like standard, if this is different for one that I had added please let me know and I can adjust it