### PR TITLE
Fixed issue where scrambler count was backwards, ship count displayed on unowned stars

### DIFF
--- a/client/src/game/star.ts
+++ b/client/src/game/star.ts
@@ -636,7 +636,7 @@ export class Star extends EventEmitter<keyof Events, Events> implements MapObjec
 
   _hasUnknownShips() {
       let carriersOrbiting = this._getStarCarriers()
-      let scramblers = carriersOrbiting.reduce( (sum, c ) => sum + (c.ships === null ? 0 : 1), 0 )
+      let scramblers = carriersOrbiting.reduce( (sum, c ) => sum + (c.ships === null ? 1 : 0), 0 )
       let scrambler = this.data.ships == null
       return ((scramblers || scrambler) && this.data.isInScanningRange)
   }
@@ -677,11 +677,11 @@ export class Star extends EventEmitter<keyof Events, Events> implements MapObjec
 
     let shipsText = ''
 
-    if (this.data.ownedByPlayerId || carriersOrbiting) {
+    if (this.data.ownedByPlayerId || carriersOrbiting.length) {
       let scramblers = 0
 
       if (carriersOrbiting) {
-        scramblers = carriersOrbiting.reduce( (sum, c ) => sum + (c.ships === null ? 0 : 1), 0 )
+        scramblers = carriersOrbiting.reduce( (sum, c ) => sum + (c.ships === null ? 1 : 0), 0 )
       }
 
       if (scramblers == carrierCount && this.data.ships == null) {


### PR DESCRIPTION
Fixes 2 small issues

* when a carrier is at a star it shows the scrambler indicator even if its not a scrambler because the logic was backwards
* Ship Counts were showing on unowned stars due to an issue where an empty array was evaluating to true to show ship counts

<img width="853" height="933" alt="image" src="https://github.com/user-attachments/assets/0a12ab32-fa70-47ea-9d1d-8dae46e24abe" />
