### PR TITLE
Fix display text

### DIFF
--- a/common/src/data/options.ts
+++ b/common/src/data/options.ts
@@ -306,7 +306,7 @@ export const GAME_CREATION_OPTIONS = {
         "specialistCost": [
             {
                 "value": "none",
-                "text": "No specialists"
+                "text": "No"
             },
             {
                 "value": "standard",


### PR DESCRIPTION
from
No specialists Specialists
to
No Specialists

<img width="275" height="111" alt="image" src="https://github.com/user-attachments/assets/6d10d644-7dc5-46a7-9189-9dcf38f4e3ca" />
