### PR TITLE
Let a new-joiner decide when to be ready themselves

### DIFF
--- a/server/services/gameJoin.ts
+++ b/server/services/gameJoin.ts
@@ -254,6 +254,8 @@ export default class GameJoinService extends EventEmitter {
 
         if (!player.userId) {
             player.ready = true;
+        } else {
+            player.ready = false;
         }
 
         if (userId) {


### PR DESCRIPTION
If a user clicks ready in a TB game and then concedes, then the next user who joins the slot will still be marked as ready.

This could cause an unpleasant surprise if everyone else is suddenly ready while the new-joiner is trying to get their bearings.