### PR TITLE
Enable MongoDB replica set in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       - "3000:3000"
     environment:
       PORT: 3000
-      CONNECTION_STRING: "mongodb://database:27017/solaris"
+      CONNECTION_STRING: "mongodb://database:27017/solaris?replicaSet=rs0"
       CLIENT_URL: "http://localhost:8080"
       CORS_URLS: "http://localhost:8080"
       SMTP_ENABLED: false
@@ -26,7 +26,7 @@ services:
     image: solaris-jobs-dev
     environment:
       PORT: 3000
-      CONNECTION_STRING: "mongodb://database:27017/solaris"
+      CONNECTION_STRING: "mongodb://database:27017/solaris?replicaSet=rs0"
       CLIENT_URL: "http://localhost:8080"
       CORS_URLS: "http://localhost:8080"
       SMTP_ENABLED: false
@@ -37,9 +37,17 @@ services:
 
   database:
     image: mongo:7
+    command: ["--replSet", "rs0", "--bind_ip_all"]
     volumes:
       - "dbdata:/data/db"
     ports:
       - "27017:27017"
+
+  mongo-init:
+    image: mongo:7
+    depends_on:
+      - database
+    restart: on-failure
+    entrypoint: ["bash", "-c", "sleep 5 && mongosh --host database:27017 --eval \"try { rs.initiate({_id:'rs0',members:[{_id:0,host:'database:27017'}]}) } catch(e) { if (e.codeName !== 'AlreadyInitialized') throw e }\""]
 volumes:
   dbdata:


### PR DESCRIPTION
## Summary
- Configures MongoDB 7 as a single-node replica set (`rs0`) to enable change streams
- Adds `mongo-init` container for automatic `rs.initiate()` on startup with retry logic
- Updates `CONNECTION_STRING` for api and jobs to include `?replicaSet=rs0`
- **Zero application code changes** — only `docker-compose.yml`

## Why
Change streams require a replica set. This unlocks real-time event observation for companion services (game archival, notifications) and is useful for any future Solaris features that need reactive database updates.

The single-node replica set has no performance overhead — MongoDB operates identically, it just enables the oplog.

## Changes
```
docker-compose.yml  |  12 ++++++++++--
1 file changed, 10 insertions(+), 2 deletions(-)
```

## Test plan
- [ ] `docker compose up -d` starts cleanly
- [ ] MongoDB replica set initializes (`rs.status()` shows PRIMARY)
- [ ] Existing game functionality completely unaffected
- [ ] API and Jobs services connect and operate normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)