### PR TITLE
Fix planets orbiting speed increasing on each map redraw

### DIFF
--- a/client/src/game/star.ts
+++ b/client/src/game/star.ts
@@ -147,6 +147,8 @@ export class Star extends EventEmitter<keyof Events, Events> implements MapObjec
     this.zoomPercent = 100
     this.showIgnoreBulkUpgradeInfrastructure = false
 
+    this.orbitPlanetsStep = this.orbitPlanetsStep.bind(this);
+
     /**
       Zoomdepth
       I'd make this an enum if I could...
@@ -1000,13 +1002,13 @@ export class Star extends EventEmitter<keyof Events, Events> implements MapObjec
 
   subscribeToEvents () {
     if (this.container_planets) {
-      this.app.ticker.add(this.orbitPlanetsStep.bind(this))
+      this.app.ticker.add(this.orbitPlanetsStep)
     }
   }
 
   unsubscribeToEvents () {
     if (this.container_planets) {
-      this.app.ticker.remove(this.orbitPlanetsStep.bind(this))
+      this.app.ticker.remove(this.orbitPlanetsStep)
     }
   }
 


### PR DESCRIPTION
When using the `Natural Resources -> Planets` setting, the planets orbiting the stars get progressively faster with each map redraw (i.e. when flipping through ticks in the time machine). This PR fixes that. See the bug in action:

https://github.com/user-attachments/assets/9fd06828-76c3-4e04-96df-530a3073875a


Cause: Because `subscribeToEvents` and `unsubscribeToEvents` each call `this.orbitPlanetsStep.bind(this)` when adding/removing the ticker callback, they create different function references. `remove` therefore doesn't remove the previously-added callback, so each redraw adds another ticker callback and the orbit updates accumulate.

Admittedly I'm not familiar with PixiJS, so I just used the same pattern as I saw used for `calcFPS` in the [debugTools.ts](https://github.com/solaris-games/solaris/blob/master/client/src/game/debugTools.ts#L30). Hopefully it doesn't break anything 😄 