### PR TITLE
Add a 'paused' state for scheduled buy actions

### DIFF
--- a/client/src/views/game/components/star/RepeatBulkUpgrade.vue
+++ b/client/src/views/game/components/star/RepeatBulkUpgrade.vue
@@ -1,8 +1,8 @@
 <template>
   <div class="position-static btn-group">
     <button class="btn btn-sm ms-1"
-      :class="{'btn-success':action.repeat,'btn-danger':!action.repeat}" @click="toggleRepeat()" >
-      <i class="fas fa-sync"></i>
+      :class="{'btn-success':action.active,'btn-danger':!action.active}" @click="toggleRepeat()" >
+      <i class="fas" style="width: 13px;" :class="{'fa-sync':action.active && action.repeat,'fa-arrow-right':action.active && !action.repeat,'fa-pause':!action.active}"></i>
     </button>
   </div>
 </template>
@@ -29,10 +29,28 @@ const toggleRepeat = async () => {
   const response = await toggleScheduledBulk(httpClient)(store.state.game._id, props.action._id);
 
   if (isOk(response)) {
-    props.action.repeat = !props.action.repeat;
+
+    // Cycle through modes:
+    // 1. repeat && active = Repeat every cycle
+    // 2. repeat && !active = Paused, but repeat every cycle
+    // 3. !repeat && active = One time only
+    if (props.action.repeat) {
+      if (props.action.active) {
+        props.action.active = !props.action.active;
+      } else {
+        props.action.active = !props.action.active;
+        props.action.repeat = !props.action.repeat;
+      }
+    } else {
+      props.action.repeat = !props.action.repeat;
+    }
 
     if (props.action.repeat) {
-      toast.default(`Your Bulk Upgrade will be repeated every cycle.`)
+      if (props.action.active) {
+        toast.default(`Your Bulk Upgrade will be repeated every cycle.`)
+      } else {
+        toast.default(`Your Bulk Upgrade is paused and will not be executed.`)
+      }
     } else {
       toast.default(`Your Bulk Upgrade will only be executed on tick ${props.action.tick}.`)
     }

--- a/common/src/types/common/player.ts
+++ b/common/src/types/common/player.ts
@@ -89,6 +89,7 @@ export interface PlayerScheduledActions<ID> {
     amount: number;
     repeat: boolean;
     tick: number;
+    active: boolean;
 }
 
 export type Player<ID> = {

--- a/server/db/models/schemas/action.ts
+++ b/server/db/models/schemas/action.ts
@@ -8,7 +8,8 @@ const schema = new Schema({
     buyType: {  type: Types.String, required: true },
     amount: { type: Types.Number, required: true, default: 0, min: 0 },
     repeat: { type: Types.Boolean, required: true, default: false },
-    tick: { type: Types.Number, required: true, default: 0, min: 0 }
+    tick: { type: Types.Number, required: true, default: 0, min: 0 },
+    active: { type: Types.Boolean, required: true, default: true },
 });
 
 export default schema;

--- a/server/services/scheduleBuy.ts
+++ b/server/services/scheduleBuy.ts
@@ -42,7 +42,7 @@ export default class ScheduleBuyService extends EventEmitter {
         for (let player of game.galaxy.players) {
             if (player.scheduledActions.length == 0) continue;
             const currentActions = player.scheduledActions
-                .filter(a => a.tick == game.state.tick) // Tick number that we just finished
+                .filter(a => a.tick == game.state.tick && a.active) // Tick number that we just finished
                 .sort((a, b) => {
                     // Take the defined priorities
                     // We sort in the order totalCredits, belowPrice, infrastructureAmount, percentageOfCredits
@@ -130,7 +130,8 @@ export default class ScheduleBuyService extends EventEmitter {
             buyType,
             amount,
             repeat,
-            tick
+            tick,
+            active: true
         }
 
         await this.gameRepo.updateOne({
@@ -149,13 +150,28 @@ export default class ScheduleBuyService extends EventEmitter {
         if (!action) {
             throw new ValidationError('Action does not exist');
         }
-        action.repeat = !action.repeat
+        
+        // Cycle through modes:
+        // 1. repeat && active = Repeat every cycle
+        // 2. repeat && !active = Paused, but repeat every cycle
+        // 3. !repeat && active = One time only
+        if (action.repeat) {
+            if (action.active) {
+                action.active = !action.active;
+            } else {
+                action.active = !action.active;
+                action.repeat = !action.repeat;
+            }
+        } else {
+            action.repeat = !action.repeat;
+        }
 
         await this.gameRepo.updateOne({
             _id: game._id,
         }, {
             $set: {
-                'galaxy.players.$[p].scheduledActions.$[a].repeat': action.repeat
+                'galaxy.players.$[p].scheduledActions.$[a].repeat': action.repeat,
+                'galaxy.players.$[p].scheduledActions.$[a].active': action.active
             }
         }, {
             arrayFilters: [

--- a/server/services/types/Player.ts
+++ b/server/services/types/Player.ts
@@ -66,6 +66,7 @@ export interface PlayerScheduledActions {
     amount: number;
     repeat: boolean;
     tick: number;
+    active: boolean;
 }
 
 export interface Player {


### PR DESCRIPTION
Heyo, I tried implementing my [suggestion](https://discord.com/channels/686524791943069734/882203122670403654/1501682087609241862) 😁 

On the backend, I think what makes the most sense is to add a boolean `active` key, rather than changing the type of the `repeat` key. 
However, UX was not so straightforward. I didn't want to add a new button to the table row, as three buttons would make it cluttered (and possibly problematic for mobiles). So I opted to add a third (paused) "mode" to the `repeat` button already present in the buy table row. This means I had to change the look of the button for the 'one-time' state, as it didn't make sense to have a red color -- I think intuitively the red color should only signalize the inactive buy action. This might be a controversial change, and I am of course very much open to feedback 😄 

This is how it looks (one-time action, repeating action, paused action):
<img width="456" height="268" alt="image" src="https://github.com/user-attachments/assets/7dcb1de0-27b7-4c88-a487-69e8024288b2" />