### PR TITLE
Custom terraforming levels in bulk upgrade

### DIFF
--- a/client/src/views/game/components/star/BulkInfrastructureUpgrade.vue
+++ b/client/src/views/game/components/star/BulkInfrastructureUpgrade.vue
@@ -70,6 +70,21 @@
               <option value="cycle-end">End of cycle</option>
             </select>
           </div>
+          <div class="mb-2 col-3" v-if="selectedScheduleStrategy === 'now'">
+            <div class="input-group">
+              <span class="input-group-text">
+                <i class="fas fa-globe-europe"></i>
+              </span>
+              <input v-on:input="resetPreview"
+                     class="form-control"
+                     id="terraforming"
+                     v-model="terraforming"
+                     type="number"
+                     required
+                     :disabled="isChecking || isUpgrading"
+              />
+            </div>
+          </div>
         </div>
         <div class="row" v-if="selectedScheduleStrategy === 'future' || selectedScheduleStrategy === 'cycle-end' || selectedScheduleStrategy === 'cycle-start'">
           <div class="mb-2 input-group col" v-if="selectedScheduleStrategy === 'future'">
@@ -117,10 +132,12 @@
         </div>
         <div class="col-4 pt-2 ps-1">
           <div class="d-grid gap-2">
-            <button class="btn btn-success" v-on:click="upgrade"
-                    :disabled="isHistoricalMode || isUpgrading || isChecking || gameIsFinished()"><i
-              class="fas fa-check me-1"></i>Confirm
-            </button>
+            <span :title="isCustomTerraforming ? 'Preview used a custom terraforming level. Reset it to your actual level to confirm.' : undefined">
+              <button class="btn btn-success w-100" v-on:click="upgrade"
+                      :disabled="isHistoricalMode || isUpgrading || isChecking || gameIsFinished() || isCustomTerraforming"><i
+                class="fas fa-check me-1"></i>Confirm
+              </button>
+            </span>
           </div>
         </div>
         <div class="col-12" v-if="ignoredCount">
@@ -184,6 +201,7 @@ const errors: Ref<string[]> = ref([]);
 const isUpgrading = ref(false);
 const isChecking = ref(false);
 const hasChecked = ref(false);
+const terraforming: Ref<number> = ref(0);
 const upgradePreview: Ref<BulkUpgradeReport<string> | null> = ref(null);
 const amount = ref(0);
 const previewAmount = ref(0);
@@ -199,6 +217,9 @@ const types: Ref<{ key: InfrastructureType, name: string }[]> = ref([]);
 const actionCount = ref(0);
 
 const isHistoricalMode = useIsHistoricalMode(store);
+
+const actualTerraformingLevel = computed(() => GameHelper.getUserPlayer(store.state.game)?.research?.terraforming?.level ?? 0);
+const isCustomTerraforming = computed(() => selectedScheduleStrategy.value === 'now' && terraforming.value !== actualTerraformingLevel.value);
 
 const checkText = computed(() => {
   if (selectedScheduleStrategy.value === 'future' || selectedScheduleStrategy.value === 'cycle-end' || selectedScheduleStrategy.value === 'cycle-start') {
@@ -263,7 +284,7 @@ const check = async () => {
   errors.value = [];
   upgradePreview.value = null;
 
-  if (!selectedType.value || amount.value <= 0 || (selectedUpgradeStrategy.value === 'percentageOfCredits' && amount.value > 100)) {
+  if (!selectedType.value || amount.value <= 0 || (selectedUpgradeStrategy.value === 'percentageOfCredits' && amount.value > 100) || terraforming.value < 1) {
     return;
   }
 
@@ -314,6 +335,7 @@ const check = async () => {
       infrastructure: selectedType.value!,
       upgradeStrategy: selectedUpgradeStrategy.value,
       amount: amount.value,
+      terraformingLevel: terraforming.value,
     });
 
     if (isOk(response)) {
@@ -379,6 +401,7 @@ onMounted(() => {
   const userPlayer = GameHelper.getUserPlayer(store.state.game)!;
   amount.value = userPlayer.credits;
   actionCount.value = userPlayer?.scheduledActions?.length || 0;
+  terraforming.value = userPlayer.research?.terraforming?.level ?? 0;
 
   setupInfrastructureTypes();
 });

--- a/common/src/api/controllers/star.ts
+++ b/common/src/api/controllers/star.ts
@@ -16,6 +16,7 @@ export type BulkUpgradeReq = {
     upgradeStrategy: string;
     infrastructure: InfrastructureType;
     amount: number;
+    terraformingLevel?: number;
 };
 
 export type ScheduleBulkUpgradeReq = {

--- a/server/api/controllers/star.ts
+++ b/server/api/controllers/star.ts
@@ -85,7 +85,8 @@ export default (container: DependencyContainer) => {
                     req.player,
                     reqObj.upgradeStrategy,
                     reqObj.infrastructure,
-                    +reqObj.amount);
+                    +reqObj.amount,
+                    reqObj.terraformingLevel);
     
                 res.status(200).json(summary);
                 return next();

--- a/server/api/requests/star.ts
+++ b/server/api/requests/star.ts
@@ -1,6 +1,6 @@
 import { DBObjectId } from "../../services/types/DBObjectId";
 import { InfrastructureType } from "../../services/types/Star";
-import {boolean, numberAdv, object, string, stringEnumeration, Validator} from "solaris-common";
+import {boolean, maybeUndefined, numberAdv, object, string, stringEnumeration, Validator} from "solaris-common";
 import {objectId} from "../../utils/validation";
 
 export interface StarUpgradeInfrastructureRequest {
@@ -15,6 +15,7 @@ export interface StarUpgradeInfrastructureBulkRequest {
     upgradeStrategy: string;
     infrastructure: InfrastructureType;
     amount: number;
+    terraformingLevel?: number;
 };
 
 const infrastructureValidator = stringEnumeration<InfrastructureType, InfrastructureType[]>(['economy', 'industry', 'science']);
@@ -26,6 +27,10 @@ export const parseStarUpgradeInfrastructureBulkRequest: Validator<StarUpgradeInf
         integer: true,
         sign: 'positive',
     }),
+    terraformingLevel: maybeUndefined(numberAdv({
+        integer: true,
+        sign: 'positive',
+    })),
 });
 
 export interface ScheduledStarUpgradeInfrastructureBulkRequest {

--- a/server/services/starUpgrade.ts
+++ b/server/services/starUpgrade.ts
@@ -409,7 +409,7 @@ export default class StarUpgradeService extends EventEmitter {
         return report;
     }
 
-    _getStarsWithNextUpgradeCost(game: Game, player: Player, infrastructureType: InfrastructureType, includeIgnored: boolean = true): UpgradeStarContext {
+    _getStarsWithNextUpgradeCost(game: Game, player: Player, infrastructureType: InfrastructureType, includeIgnored: boolean = true, customTerraformingLevel?: number): UpgradeStarContext {
         let expenseConfig: number | null;
         let calculateCostFunction: (game: Game, expenseConfig: number | null, current: number, terraformedResources: number) => null | number;
 
@@ -446,7 +446,8 @@ export default class StarUpgradeService extends EventEmitter {
 
         const mapStarToUpgrade = (s: Star): UpgradeStar => {
             const effectiveTechs = this.technologyService.getStarEffectiveTechnologyLevels(game, s);
-            const terraformedResources = this.starService.calculateTerraformedResource(s.naturalResources[infrastructureType], effectiveTechs.terraforming);
+            const terraformingLevel = customTerraformingLevel ?? effectiveTechs.terraforming;
+            const terraformedResources = this.starService.calculateTerraformedResource(s.naturalResources[infrastructureType], terraformingLevel);
             const infrastructureCost = calculateCostFunction(game, expenseConfig, s.infrastructure[infrastructureType]!, terraformedResources)!;
 
             return {
@@ -610,7 +611,7 @@ export default class StarUpgradeService extends EventEmitter {
         });
     }
 
-    generateUpgradeBulkReport(game: Game, player: Player, upgradeStrategy: string, infrastructureType: InfrastructureType, amount: number): BulkUpgradeReport {
+    generateUpgradeBulkReport(game: Game, player: Player, upgradeStrategy: string, infrastructureType: InfrastructureType, amount: number, customTerraformingLevel?: number): BulkUpgradeReport {
         if (!amount || amount <= 0) {
             throw new ValidationError(`Invalid upgrade amount given`);
         }
@@ -621,13 +622,13 @@ export default class StarUpgradeService extends EventEmitter {
 
         // Get all of the player stars and what the next upgrade cost will be.
         if (upgradeStrategy === 'totalCredits') {
-            return this.generateUpgradeBulkReportTotalCredits(game, player, infrastructureType, amount);
+            return this.generateUpgradeBulkReportTotalCredits(game, player, infrastructureType, amount, customTerraformingLevel);
         } else if (upgradeStrategy === 'percentageOfCredits') {
-            return this.generateUpgradeBulkReportPercentageOfCredits(game, player, infrastructureType, amount);
+            return this.generateUpgradeBulkReportPercentageOfCredits(game, player, infrastructureType, amount, customTerraformingLevel);
         } else if (upgradeStrategy === 'infrastructureAmount') {
-            return this.generateUpgradeBulkReportInfrastructureAmount(game, player, infrastructureType, amount);
+            return this.generateUpgradeBulkReportInfrastructureAmount(game, player, infrastructureType, amount, customTerraformingLevel);
         } else if (upgradeStrategy === 'belowPrice') {
-            return this.generateUpgradeBulkReportBelowPrice(game, player, infrastructureType, amount);
+            return this.generateUpgradeBulkReportBelowPrice(game, player, infrastructureType, amount, customTerraformingLevel);
         }
 
         throw new Error(`Unsupported upgrade strategy: ${upgradeStrategy}`);
@@ -693,9 +694,9 @@ export default class StarUpgradeService extends EventEmitter {
         }
     }
 
-    generateUpgradeBulkReportBelowPrice(game: Game, player: Player, infrastructureType: InfrastructureType, amount: number): BulkUpgradeReport {
+    generateUpgradeBulkReportBelowPrice(game: Game, player: Player, infrastructureType: InfrastructureType, amount: number, customTerraformingLevel?: number): BulkUpgradeReport {
         const ignoredCount = this.starService.listStarsOwnedByPlayerBulkIgnored(game.galaxy.stars, player._id, infrastructureType).length;
-        const upgradeContext = this._getStarsWithNextUpgradeCost(game, player, infrastructureType, false);
+        const upgradeContext = this._getStarsWithNextUpgradeCost(game, player, infrastructureType, false, customTerraformingLevel);
 
         const upgradeSummary: BulkUpgradeReport = {
             budget: amount,
@@ -729,11 +730,11 @@ export default class StarUpgradeService extends EventEmitter {
         return upgradeSummary
     }
 
-    generateUpgradeBulkReportInfrastructureAmount(game: Game, player: Player, infrastructureType: InfrastructureType, amount: number): BulkUpgradeReport {
+    generateUpgradeBulkReportInfrastructureAmount(game: Game, player: Player, infrastructureType: InfrastructureType, amount: number, customTerraformingLevel?: number): BulkUpgradeReport {
         //Enforce some max size constraint
         amount = Math.min(amount, 200);
         const ignoredCount = this.starService.listStarsOwnedByPlayerBulkIgnored(game.galaxy.stars, player._id, infrastructureType).length;
-        const upgradeContext = this._getStarsWithNextUpgradeCost(game, player, infrastructureType, false);
+        const upgradeContext = this._getStarsWithNextUpgradeCost(game, player, infrastructureType, false, customTerraformingLevel);
 
         const upgradeSummary: BulkUpgradeReport = {
             budget: amount,
@@ -765,9 +766,9 @@ export default class StarUpgradeService extends EventEmitter {
         return upgradeSummary;
     }
 
-    generateUpgradeBulkReportTotalCredits(game: Game, player: Player, infrastructureType: InfrastructureType, budget: number): BulkUpgradeReport {
+    generateUpgradeBulkReportTotalCredits(game: Game, player: Player, infrastructureType: InfrastructureType, budget: number, customTerraformingLevel?: number): BulkUpgradeReport {
         const ignoredCount = this.starService.listStarsOwnedByPlayerBulkIgnored(game.galaxy.stars, player._id, infrastructureType).length;
-        const upgradeContext = this._getStarsWithNextUpgradeCost(game, player, infrastructureType, false);
+        const upgradeContext = this._getStarsWithNextUpgradeCost(game, player, infrastructureType, false, customTerraformingLevel);
 
         budget = Math.min(budget, player.credits + 10000); // Prevent players from generating reports for stupid amounts of credits
 
@@ -803,10 +804,10 @@ export default class StarUpgradeService extends EventEmitter {
         return upgradeSummary;
     }
 
-    generateUpgradeBulkReportPercentageOfCredits(game: Game, player: Player, infrastructureType: InfrastructureType, percentage: number): BulkUpgradeReport {
+    generateUpgradeBulkReportPercentageOfCredits(game: Game, player: Player, infrastructureType: InfrastructureType, percentage: number, customTerraformingLevel?: number): BulkUpgradeReport {
         percentage = Math.min(100, Math.max(0, percentage));
         const budget = Math.ceil(player.credits * percentage / 100);
-        return this.generateUpgradeBulkReportTotalCredits(game, player, infrastructureType, budget);
+        return this.generateUpgradeBulkReportTotalCredits(game, player, infrastructureType, budget, customTerraformingLevel);
     }
 
     calculateAverageTerraformedResources(terraformedResources: TerraformedResources) {


### PR DESCRIPTION
Closes #997 
Implementing suggestion from https://discord.com/channels/686524791943069734/882203122670403654/1467980627457478686 and https://discord.com/channels/686524791943069734/882203122670403654/1130695075333161051

This adds a small input to the Bulk Upgrade window, pre-filled with the player's current terraforming level. The input is only shown if the selected schedule strategy is `now` (as it doesn't make sense for other schedule strategies). 

<img width="469" height="432" alt="image" src="https://github.com/user-attachments/assets/2d58aeb6-0383-4acb-8e73-c1ad671f846c" />


Player can adjust this value to see the potential outcome of the bulk upgrade as if he had that terraforming level. The Confirm button is disabled if using a different level from the current level, and the button has a standarn hover tooltip explaining why.

<img width="896" height="433" alt="image" src="https://github.com/user-attachments/assets/bd87cdad-088e-42ba-b93c-43b3206f0157" />
