### PR TITLE
In "my games", show how many players have confirmed their turns for a TB game

### DIFF
--- a/client/src/views/game/components/gameList/ActiveGames.vue
+++ b/client/src/views/game/components/gameList/ActiveGames.vue
@@ -37,7 +37,7 @@
                     <br/>
                     <span v-if="game.userNotifications.defeated && !game.userNotifications.afk" class="me-1 badge bg-danger">Defeated</span>
                     <span v-if="!game.userNotifications.defeated && game.userNotifications.turnWaiting" class="me-1 badge bg-danger">Turn Waiting</span>
-                    <span v-if="!game.userNotifications.defeated && game.userNotifications.turnTotalCount != null" class="me-1 badge bg-info">{{game.userNotifications.turnReadyCount}}/{{game.userNotifications.turnTotalCount}} Ready</span>
+                    <span v-if="!game.userNotifications.defeated && game.userNotifications.turnTotalCount != null" class="me-1 badge bg-secondary">{{game.userNotifications.turnReadyCount}}/{{game.userNotifications.turnTotalCount}} Ready</span>
                     <span v-if="!game.userNotifications.defeated && game.userNotifications.unreadEvents" class="me-1 badge bg-warning">{{game.userNotifications.unreadEvents}} Events</span>
                     <span v-if="game.userNotifications.afk" class="me-1 badge bg-warning">AFK</span>
                     <span v-if="game.userNotifications.unreadConversations" class="me-1 badge bg-info">{{game.userNotifications.unreadConversations}} Messages</span>

--- a/client/src/views/game/components/gameList/ActiveGames.vue
+++ b/client/src/views/game/components/gameList/ActiveGames.vue
@@ -37,6 +37,7 @@
                     <br/>
                     <span v-if="game.userNotifications.defeated && !game.userNotifications.afk" class="me-1 badge bg-danger">Defeated</span>
                     <span v-if="!game.userNotifications.defeated && game.userNotifications.turnWaiting" class="me-1 badge bg-danger">Turn Waiting</span>
+                    <span v-if="!game.userNotifications.defeated && game.userNotifications.turnTotalCount != null" class="me-1 badge bg-info">{{game.userNotifications.turnReadyCount}}/{{game.userNotifications.turnTotalCount}} Ready</span>
                     <span v-if="!game.userNotifications.defeated && game.userNotifications.unreadEvents" class="me-1 badge bg-warning">{{game.userNotifications.unreadEvents}} Events</span>
                     <span v-if="game.userNotifications.afk" class="me-1 badge bg-warning">AFK</span>
                     <span v-if="game.userNotifications.unreadConversations" class="me-1 badge bg-info">{{game.userNotifications.unreadConversations}} Messages</span>

--- a/common/src/types/common/game.ts
+++ b/common/src/types/common/game.ts
@@ -476,6 +476,8 @@ export type GameUserNotification = {
 	unreadEvents: number | null;
 	unread: number | null;
 	turnWaiting: boolean | null;
+	turnReadyCount: number | null;
+	turnTotalCount: number | null;
 	defeated: boolean | null;
 	afk: boolean | null;
 	position: number | null;

--- a/server/services/gameList.ts
+++ b/server/services/gameList.ts
@@ -255,6 +255,8 @@ export default class GameListService {
             unreadEvents: number | null = null,
             totalUnread: number | null = null,
             turnWaiting: boolean | null = null,
+            turnReadyCount: number | null = null,
+            turnTotalCount: number | null = null,
             position: number | null = null;
 
         // Note: The player may have gone afk and been replaced by another player so we need to
@@ -262,7 +264,12 @@ export default class GameListService {
         if (player) {
             if (includeUnreadConversastions) unreadConversations = this.conversationService.getUnreadCount(game, player._id);
             if (includeUnreadEvents) unreadEvents = await this.eventService.getUnreadCount(game, player._id);
-            if (includeTurnWaiting) turnWaiting = this.gameTypeService.isTurnBasedGame(game) && !player.ready;
+            if (includeTurnWaiting && this.gameTypeService.isTurnBasedGame(game)) {
+                turnWaiting = !player.ready;
+                const undefeatedPlayers = game.galaxy.players.filter(p => !p.defeated);
+                turnReadyCount = undefeatedPlayers.filter(p => p.ready).length;
+                turnTotalCount = undefeatedPlayers.length;
+            }
 
             totalUnread = (unreadConversations || 0) + (unreadEvents || 0);
 
@@ -280,6 +287,8 @@ export default class GameListService {
             unreadEvents,
             unread: totalUnread,
             turnWaiting,
+            turnReadyCount,
+            turnTotalCount,
             defeated: player?.defeated || null,
             afk: player?.afk || null,
             position

--- a/server/services/types/Game.ts
+++ b/server/services/types/Game.ts
@@ -11,6 +11,8 @@ export interface GameUserNotification {
 	unreadEvents: number | null;
 	unread: number | null;
 	turnWaiting: boolean | null;
+	turnReadyCount: number | null;
+	turnTotalCount: number | null;
 	defeated: boolean | null;
 	afk: boolean | null;
 	position: number | null;


### PR DESCRIPTION
Closes #1484 

Quite straightforward, just adding an informational badge with ready/total players for TB games.

When player has not ended their turn:
<img width="813" height="118" alt="image" src="https://github.com/user-attachments/assets/c84b4b1a-4809-4a47-bf7e-fa6c6b704c96" />


When player has ended their turn:
<img width="812" height="117" alt="image" src="https://github.com/user-attachments/assets/5f25ae4e-2037-46ee-b34e-d67df8dccb02" />
