### PR TITLE
Beta branch - proposed fix for ship kill count in statistics

### DIFF
--- a/common/spec/combat.spec.ts
+++ b/common/spec/combat.spec.ts
@@ -644,97 +644,9 @@ describe("CombatService – computeGroups", () => {
             expect(g.shipsLost).toBe(g.shipsBefore - g.shipsAfter);
         }
     });
-
-    it("shipKill counts - does not over-credit or under-credit shipsKilled", () => {
-        // This test is designed to catch the bug where each attacker gets credited
-        // with min(rawDamage, targetActualKills), causing total credited kills to
-        // exceed total ships actually lost.
-        //
-        // Initial:
-        // G0: 5 ships, deals 0 damage
-        // G1: 8 ships, deals 8 to G0 and 8 to G2
-        // G2: 8 ships, deals 8 to G0 and 8 to G1
-        //
-        // Single simultaneous carrier-to-carrier round:
-        // G0 takes 16 incoming damage but only has 5 ships -> loses 5
-        // G1 takes 8 incoming damage -> loses 8
-        // G2 takes 8 incoming damage -> loses 8
-        //
-        // All groups are dead after one round.
-        //
-        // Actual total ships lost = 5 + 8 + 8 = 21.
-        //
-        // Broken per-attacker cap behavior:
-        // G1 gets min(8, 5) = 5 kills on G0, plus 8 kills on G2 = 13
-        // G2 gets min(8, 5) = 5 kills on G0, plus 8 kills on G1 = 13
-        // Total credited kills = 26, which is impossible.
-
-        const groups: TestGroup[] = [
-            makeGroup("p0", 5, 0, false, [
-                [1, 0],
-                [2, 0],
-            ]),
-            makeGroup("p1", 8, 8, false, [
-                [0, 8],
-                [2, 8],
-            ]),
-            makeGroup("p2", 8, 8, false, [
-                [0, 8],
-                [1, 8],
-            ]),
-        ];
-
-        const result = service.calculateGroups(groups, false);
-
-        expect(result.groups[0].shipsAfter).toBe(0);
-        expect(result.groups[1].shipsAfter).toBe(0);
-        expect(result.groups[2].shipsAfter).toBe(0);
-
-        const totalShipsLost = result.groups.reduce(
-            (sum, group) => sum + group.shipsLost,
-            0,
-        );
-
-        const totalShipsKilled = result.groups.reduce(
-            (sum, group) => sum + group.shipsKilled,
-            0,
-        );
-
-        expect(totalShipsLost).toBe(21);
-        expect(totalShipsKilled).toBe(totalShipsLost);
-    });
 });
 
 describe("CombatService - shipsKilled", () => {
-    type TestPlayer = {
-        _id: string;
-        research: {
-            weapons: {
-                level: number;
-            };
-        };
-    };
-
-    function makeWeaponsDetail(level: number): WeaponsDetail {
-        return {
-            total: level,
-            weaponsLevel: level,
-            weaponsBuff: 0,
-            appliedBuffs: [],
-        };
-    }
-
-    function makePlayer(id: string, weaponsLevel: number): TestPlayer {
-        return {
-            _id: id,
-            research: {
-                weapons: {
-                    level: weaponsLevel,
-                },
-            },
-        };
-    }
-
     function makeGame(players: TestPlayer[]) {
         return {
             galaxy: {
@@ -743,29 +655,7 @@ describe("CombatService - shipsKilled", () => {
         } as any;
     }
 
-    function makeStar(id: string, ownedByPlayerId: string, ships: number) {
-        return {
-            _id: id,
-            ownedByPlayerId,
-            ships,
-            specialistId: null,
-            specialistTargetedPlayers: [],
-            isAsteroidField: false,
-            homeStar: false,
-        } as any;
-    }
-
-    function makeCarrier(id: string, ownedByPlayerId: string, ships: number) {
-        return {
-            _id: id,
-            ownedByPlayerId,
-            ships,
-            specialistId: null,
-            specialistTargetedPlayers: [],
-        } as any;
-    }
-
-    function makeService() {
+    function makeCombatService() {
         const combatGroupService = {
             computeCombatGroups: jasmine
                 .createSpy("computeCombatGroups")
@@ -779,14 +669,18 @@ describe("CombatService - shipsKilled", () => {
         const technologyService = {
             getEffectiveWeaponsDetail: jasmine
                 .createSpy("getEffectiveWeaponsDetail")
-                .and.callFake((_game: any, group: any) => {
-                    return makeWeaponsDetail(group.players[0].research.weapons.level);
+                .and.callFake((_game: any, group: TestGroup) => {
+                    return makeWeaponsDetail(
+                        group.players[0].research.weapons.level,
+                    );
                 }),
         };
 
         const specialistService = {
             getByIdStar: jasmine.createSpy("getByIdStar").and.returnValue(null),
-            getByIdCarrier: jasmine.createSpy("getByIdCarrier").and.returnValue(null),
+            getByIdCarrier: jasmine
+                .createSpy("getByIdCarrier")
+                .and.returnValue(null),
         };
 
         return new CombatService(
@@ -794,6 +688,34 @@ describe("CombatService - shipsKilled", () => {
             technologyService as any,
             specialistService as any,
         );
+    }
+
+    function totalShipsLost(result: any): number {
+        return result.groups.reduce(
+            (sum: number, group: any) => sum + group.shipsLost,
+            0,
+        );
+    }
+
+    function totalShipsKilled(result: any): number {
+        return result.groups.reduce(
+            (sum: number, group: any) => sum + group.shipsKilled,
+            0,
+        );
+    }
+
+    function expectTotalShipsKilledToEqualShipsLost(
+        result: any,
+        expectedShipsLost?: number,
+    ) {
+        const lost = totalShipsLost(result);
+        const killed = totalShipsKilled(result);
+
+        if (expectedShipsLost !== undefined) {
+            expect(lost).toBe(expectedShipsLost);
+        }
+
+        expect(killed).toBe(lost);
     }
 
     function runComputeStarScenario(params: {
@@ -809,14 +731,17 @@ describe("CombatService - shipsKilled", () => {
         const attacker = makePlayer("attacker", attackerWeapons);
 
         const game = makeGame([defender, attacker]);
-        const star = makeStar("star", "defender", params.starShips);
-        const carrier = makeCarrier("carrier", "attacker", params.carrierShips);
+        const star = makeStar("star", "defender", params.starShips) as any;
+        const carrier = makeCarrier(
+            "carrier",
+            "attacker",
+            params.carrierShips,
+        ) as any;
 
-        const service = makeService();
-
+        const combatService = makeCombatService();
         const callbackStates: any[] = [];
 
-        const result = service.computeStar(
+        const result = combatService.computeStar(
             game,
             star,
             [carrier],
@@ -836,128 +761,145 @@ describe("CombatService - shipsKilled", () => {
         };
     }
 
-    [
-        {
-            name: "equal 10v10 takes multiple rounds and defender first shot matters",
-            starShips: 10,
-            carrierShips: 10,
-            expectedDefenderShipsAfter: 1,
-            expectedAttackerShipsAfter: 0,
-            expectedDefenderShipsKilled: 10,
-            expectedAttackerShipsKilled: 9,
-        },
-        {
-            name: "1v2 mutual destruction catches defender-first off-by-one",
-            starShips: 1,
-            carrierShips: 2,
-            expectedDefenderShipsAfter: 0,
-            expectedAttackerShipsAfter: 0,
-            expectedDefenderShipsKilled: 2,
-            expectedAttackerShipsKilled: 1,
-        },
-        {
-            name: "10v50 attacker wins but defender still killed more than one round",
-            starShips: 10,
-            carrierShips: 50,
-            expectedDefenderShipsAfter: 0,
-            expectedAttackerShipsAfter: 39,
-            expectedDefenderShipsKilled: 11,
-            expectedAttackerShipsKilled: 10,
-        },
-        {
-            name: "25v50 with 7v8 weapons caps final-round overkill",
-            starShips: 25,
-            carrierShips: 50,
-            defenderWeapons: 7,
-            attackerWeapons: 8,
-            expectedDefenderShipsAfter: 0,
-            expectedAttackerShipsAfter: 21,
-            expectedDefenderShipsKilled: 29,
-            expectedAttackerShipsKilled: 25,
-        },
-    ].forEach((tc) => {
-        it(`shipsKilled counts - records total shipsKilled for computeStar: ${tc.name}`, () => {
-            const { defenderGroup, attackerGroup, callbackStates } =
-                runComputeStarScenario({
+    describe("calculateGroups", () => {
+        it("does not over-credit or under-credit shipsKilled", () => {
+            // G0 loses only 5 ships, even though G1 and G2 each deal 8 damage
+            // to it. Kill credit for G0's losses must be capped at 5 total,
+            // not 5 per attacker.
+            const groups: TestGroup[] = [
+                makeGroup("p0", 5, 0, false, [
+                    [1, 0],
+                    [2, 0],
+                ]),
+                makeGroup("p1", 8, 8, false, [
+                    [0, 8],
+                    [2, 8],
+                ]),
+                makeGroup("p2", 8, 8, false, [
+                    [0, 8],
+                    [1, 8],
+                ]),
+            ];
+
+            const result = service.calculateGroups(groups, false);
+
+            result.groups.forEach((group) => {
+                expect(group.shipsAfter).toBe(0);
+            });
+
+            expectTotalShipsKilledToEqualShipsLost(result, 21);
+
+            // Optional but useful: G0 dealt no damage, so it should not receive
+            // any ship kill credit.
+            expect(result.groups[0].shipsKilled).toBe(0);
+        });
+
+        it("assigns multiple leftover fractional kill credits when needed", () => {
+            // G0 loses 2 ships from 3 equal attackers.
+            // Exact credit is 0.666... each, so flooring gives 0 total.
+            // Both leftover kills must still be assigned.
+            const groups: TestGroup[] = [
+                makeGroup("p0", 2, 0, false, [
+                    [1, 0],
+                    [2, 0],
+                    [3, 0],
+                ]),
+                makeGroup("p1", 1, 1, false, [
+                    [0, 1],
+                    [2, 1],
+                    [3, 1],
+                ]),
+                makeGroup("p2", 1, 1, false, [
+                    [0, 1],
+                    [1, 1],
+                    [3, 1],
+                ]),
+                makeGroup("p3", 1, 1, false, [
+                    [0, 1],
+                    [1, 1],
+                    [2, 1],
+                ]),
+            ];
+
+            const result = service.calculateGroups(groups, false);
+
+            result.groups.forEach((group) => {
+                expect(group.shipsAfter).toBe(0);
+            });
+
+            expectTotalShipsKilledToEqualShipsLost(result, 5);
+        });
+    });
+
+    describe("computeStar", () => {
+        [
+            {
+                name: "equal 10v10 takes multiple rounds and defender first shot matters",
+                starShips: 10,
+                carrierShips: 10,
+                expectedDefenderShipsAfter: 1,
+                expectedAttackerShipsAfter: 0,
+                expectedDefenderShipsKilled: 10,
+                expectedAttackerShipsKilled: 9,
+            },
+            {
+                name: "1v2 mutual destruction catches defender-first off-by-one",
+                starShips: 1,
+                carrierShips: 2,
+                expectedDefenderShipsAfter: 0,
+                expectedAttackerShipsAfter: 0,
+                expectedDefenderShipsKilled: 2,
+                expectedAttackerShipsKilled: 1,
+            },
+            {
+                name: "10v50 attacker wins but defender still killed more than one round",
+                starShips: 10,
+                carrierShips: 50,
+                expectedDefenderShipsAfter: 0,
+                expectedAttackerShipsAfter: 39,
+                expectedDefenderShipsKilled: 11,
+                expectedAttackerShipsKilled: 10,
+            },
+            {
+                name: "25v50 with 7v8 weapons caps final-round overkill",
+                starShips: 25,
+                carrierShips: 50,
+                defenderWeapons: 7,
+                attackerWeapons: 8,
+                expectedDefenderShipsAfter: 0,
+                expectedAttackerShipsAfter: 21,
+                expectedDefenderShipsKilled: 29,
+                expectedAttackerShipsKilled: 25,
+            },
+        ].forEach((tc) => {
+            it(`records total shipsKilled: ${tc.name}`, () => {
+                const {
+                    defenderGroup,
+                    attackerGroup,
+                    callbackStates,
+                } = runComputeStarScenario({
                     starShips: tc.starShips,
                     carrierShips: tc.carrierShips,
                     defenderWeapons: tc.defenderWeapons,
                     attackerWeapons: tc.attackerWeapons,
                 });
 
-            expect(callbackStates[callbackStates.length - 1].round).toBeGreaterThan(1);
+                expect(callbackStates[callbackStates.length - 1].round)
+                    .toBeGreaterThan(1);
 
-            expect(defenderGroup.shipsAfter).toBe(tc.expectedDefenderShipsAfter);
-            expect(attackerGroup.shipsAfter).toBe(tc.expectedAttackerShipsAfter);
+                expect(defenderGroup.shipsAfter)
+                    .toBe(tc.expectedDefenderShipsAfter);
+                expect(attackerGroup.shipsAfter)
+                    .toBe(tc.expectedAttackerShipsAfter);
 
-            expect(defenderGroup.shipsKilled).toBe(tc.expectedDefenderShipsKilled);
-            expect(attackerGroup.shipsKilled).toBe(tc.expectedAttackerShipsKilled);
+                expect(defenderGroup.shipsKilled)
+                    .toBe(tc.expectedDefenderShipsKilled);
+                expect(attackerGroup.shipsKilled)
+                    .toBe(tc.expectedAttackerShipsKilled);
 
-            expect(defenderGroup.shipsKilled).toBe(attackerGroup.shipsLost);
-            expect(attackerGroup.shipsKilled).toBe(defenderGroup.shipsLost);
+                expect(defenderGroup.shipsKilled).toBe(attackerGroup.shipsLost);
+                expect(attackerGroup.shipsKilled).toBe(defenderGroup.shipsLost);
+            });
         });
-    });
-
-    it("shipKill counts - assigns multiple leftover fractional kill credits when needed", () => {
-        // This catches a bug where only one fractional leftover kill is assigned.
-        //
-        // Group 0 has 2 ships.
-        // Groups 1, 2, and 3 each deal 1 damage to Group 0.
-        //
-        // Group 0 receives 3 raw damage but only loses 2 ships.
-        //
-        // Exact kill credit against Group 0:
-        // Group 1: 1 / 3 * 2 = 0.666...
-        // Group 2: 1 / 3 * 2 = 0.666...
-        // Group 3: 1 / 3 * 2 = 0.666...
-        //
-        // Flooring gives:
-        // 0 + 0 + 0 = 0
-        //
-        // There are 2 leftover kills to assign.
-        // A broken "only assign one fractional kill" implementation would credit
-        // only 1 kill for Group 0's 2 lost ships.
-
-        const groups: TestGroup[] = [
-            makeGroup("p0", 2, 0, false, [
-                [1, 0],
-                [2, 0],
-                [3, 0],
-            ]),
-            makeGroup("p1", 1, 1, false, [
-                [0, 1],
-                [2, 1],
-                [3, 1],
-            ]),
-            makeGroup("p2", 1, 1, false, [
-                [0, 1],
-                [1, 1],
-                [3, 1],
-            ]),
-            makeGroup("p3", 1, 1, false, [
-                [0, 1],
-                [1, 1],
-                [2, 1],
-            ]),
-        ];
-
-        const result = service.calculateGroups(groups, false);
-
-        result.groups.forEach((group) => {
-            expect(group.shipsAfter).toBe(0);
-        });
-
-        const totalShipsLost = result.groups.reduce(
-            (sum, group) => sum + group.shipsLost,
-            0,
-        );
-
-        const totalShipsKilled = result.groups.reduce(
-            (sum, group) => sum + group.shipsKilled,
-            0,
-        );
-
-        expect(totalShipsLost).toBe(5);
-        expect(totalShipsKilled).toBe(totalShipsLost);
     });
 });

--- a/common/spec/combat.spec.ts
+++ b/common/spec/combat.spec.ts
@@ -644,4 +644,320 @@ describe("CombatService – computeGroups", () => {
             expect(g.shipsLost).toBe(g.shipsBefore - g.shipsAfter);
         }
     });
+
+    it("shipKill counts - does not over-credit or under-credit shipsKilled", () => {
+        // This test is designed to catch the bug where each attacker gets credited
+        // with min(rawDamage, targetActualKills), causing total credited kills to
+        // exceed total ships actually lost.
+        //
+        // Initial:
+        // G0: 5 ships, deals 0 damage
+        // G1: 8 ships, deals 8 to G0 and 8 to G2
+        // G2: 8 ships, deals 8 to G0 and 8 to G1
+        //
+        // Single simultaneous carrier-to-carrier round:
+        // G0 takes 16 incoming damage but only has 5 ships -> loses 5
+        // G1 takes 8 incoming damage -> loses 8
+        // G2 takes 8 incoming damage -> loses 8
+        //
+        // All groups are dead after one round.
+        //
+        // Actual total ships lost = 5 + 8 + 8 = 21.
+        //
+        // Broken per-attacker cap behavior:
+        // G1 gets min(8, 5) = 5 kills on G0, plus 8 kills on G2 = 13
+        // G2 gets min(8, 5) = 5 kills on G0, plus 8 kills on G1 = 13
+        // Total credited kills = 26, which is impossible.
+
+        const groups: TestGroup[] = [
+            makeGroup("p0", 5, 0, false, [
+                [1, 0],
+                [2, 0],
+            ]),
+            makeGroup("p1", 8, 8, false, [
+                [0, 8],
+                [2, 8],
+            ]),
+            makeGroup("p2", 8, 8, false, [
+                [0, 8],
+                [1, 8],
+            ]),
+        ];
+
+        const result = service.calculateGroups(groups, false);
+
+        expect(result.groups[0].shipsAfter).toBe(0);
+        expect(result.groups[1].shipsAfter).toBe(0);
+        expect(result.groups[2].shipsAfter).toBe(0);
+
+        const totalShipsLost = result.groups.reduce(
+            (sum, group) => sum + group.shipsLost,
+            0,
+        );
+
+        const totalShipsKilled = result.groups.reduce(
+            (sum, group) => sum + group.shipsKilled,
+            0,
+        );
+
+        expect(totalShipsLost).toBe(21);
+        expect(totalShipsKilled).toBe(totalShipsLost);
+    });
+});
+
+describe("CombatService - shipsKilled", () => {
+    type TestPlayer = {
+        _id: string;
+        research: {
+            weapons: {
+                level: number;
+            };
+        };
+    };
+
+    function makeWeaponsDetail(level: number): WeaponsDetail {
+        return {
+            total: level,
+            weaponsLevel: level,
+            weaponsBuff: 0,
+            appliedBuffs: [],
+        };
+    }
+
+    function makePlayer(id: string, weaponsLevel: number): TestPlayer {
+        return {
+            _id: id,
+            research: {
+                weapons: {
+                    level: weaponsLevel,
+                },
+            },
+        };
+    }
+
+    function makeGame(players: TestPlayer[]) {
+        return {
+            galaxy: {
+                players,
+            },
+        } as any;
+    }
+
+    function makeStar(id: string, ownedByPlayerId: string, ships: number) {
+        return {
+            _id: id,
+            ownedByPlayerId,
+            ships,
+            specialistId: null,
+            specialistTargetedPlayers: [],
+            isAsteroidField: false,
+            homeStar: false,
+        } as any;
+    }
+
+    function makeCarrier(id: string, ownedByPlayerId: string, ships: number) {
+        return {
+            _id: id,
+            ownedByPlayerId,
+            ships,
+            specialistId: null,
+            specialistTargetedPlayers: [],
+        } as any;
+    }
+
+    function makeService() {
+        const combatGroupService = {
+            computeCombatGroups: jasmine
+                .createSpy("computeCombatGroups")
+                .and.callFake((_game: any, players: TestPlayer[]) => {
+                    return {
+                        groups: players.map((p) => [p]),
+                    };
+                }),
+        };
+
+        const technologyService = {
+            getEffectiveWeaponsDetail: jasmine
+                .createSpy("getEffectiveWeaponsDetail")
+                .and.callFake((_game: any, group: any) => {
+                    return makeWeaponsDetail(group.players[0].research.weapons.level);
+                }),
+        };
+
+        const specialistService = {
+            getByIdStar: jasmine.createSpy("getByIdStar").and.returnValue(null),
+            getByIdCarrier: jasmine.createSpy("getByIdCarrier").and.returnValue(null),
+        };
+
+        return new CombatService(
+            combatGroupService as any,
+            technologyService as any,
+            specialistService as any,
+        );
+    }
+
+    function runComputeStarScenario(params: {
+        starShips: number;
+        carrierShips: number;
+        defenderWeapons?: number;
+        attackerWeapons?: number;
+    }) {
+        const defenderWeapons = params.defenderWeapons ?? 1;
+        const attackerWeapons = params.attackerWeapons ?? 1;
+
+        const defender = makePlayer("defender", defenderWeapons);
+        const attacker = makePlayer("attacker", attackerWeapons);
+
+        const game = makeGame([defender, attacker]);
+        const star = makeStar("star", "defender", params.starShips);
+        const carrier = makeCarrier("carrier", "attacker", params.carrierShips);
+
+        const service = makeService();
+
+        const callbackStates: any[] = [];
+
+        const result = service.computeStar(
+            game,
+            star,
+            [carrier],
+            (state) => callbackStates.push(state),
+        );
+
+        expect(result).toBeDefined();
+
+        const defenderGroup = result!.groups.find((g) => g.star)!;
+        const attackerGroup = result!.groups.find((g) => g.carriers.length)!;
+
+        return {
+            result: result!,
+            defenderGroup,
+            attackerGroup,
+            callbackStates,
+        };
+    }
+
+    [
+        {
+            name: "equal 10v10 takes multiple rounds and defender first shot matters",
+            starShips: 10,
+            carrierShips: 10,
+            expectedDefenderShipsAfter: 1,
+            expectedAttackerShipsAfter: 0,
+            expectedDefenderShipsKilled: 10,
+            expectedAttackerShipsKilled: 9,
+        },
+        {
+            name: "1v2 mutual destruction catches defender-first off-by-one",
+            starShips: 1,
+            carrierShips: 2,
+            expectedDefenderShipsAfter: 0,
+            expectedAttackerShipsAfter: 0,
+            expectedDefenderShipsKilled: 2,
+            expectedAttackerShipsKilled: 1,
+        },
+        {
+            name: "10v50 attacker wins but defender still killed more than one round",
+            starShips: 10,
+            carrierShips: 50,
+            expectedDefenderShipsAfter: 0,
+            expectedAttackerShipsAfter: 39,
+            expectedDefenderShipsKilled: 11,
+            expectedAttackerShipsKilled: 10,
+        },
+        {
+            name: "25v50 with 7v8 weapons caps final-round overkill",
+            starShips: 25,
+            carrierShips: 50,
+            defenderWeapons: 7,
+            attackerWeapons: 8,
+            expectedDefenderShipsAfter: 0,
+            expectedAttackerShipsAfter: 21,
+            expectedDefenderShipsKilled: 29,
+            expectedAttackerShipsKilled: 25,
+        },
+    ].forEach((tc) => {
+        it(`shipsKilled counts - records total shipsKilled for computeStar: ${tc.name}`, () => {
+            const { defenderGroup, attackerGroup, callbackStates } =
+                runComputeStarScenario({
+                    starShips: tc.starShips,
+                    carrierShips: tc.carrierShips,
+                    defenderWeapons: tc.defenderWeapons,
+                    attackerWeapons: tc.attackerWeapons,
+                });
+
+            expect(callbackStates[callbackStates.length - 1].round).toBeGreaterThan(1);
+
+            expect(defenderGroup.shipsAfter).toBe(tc.expectedDefenderShipsAfter);
+            expect(attackerGroup.shipsAfter).toBe(tc.expectedAttackerShipsAfter);
+
+            expect(defenderGroup.shipsKilled).toBe(tc.expectedDefenderShipsKilled);
+            expect(attackerGroup.shipsKilled).toBe(tc.expectedAttackerShipsKilled);
+
+            expect(defenderGroup.shipsKilled).toBe(attackerGroup.shipsLost);
+            expect(attackerGroup.shipsKilled).toBe(defenderGroup.shipsLost);
+        });
+    });
+
+    it("shipKill counts - assigns multiple leftover fractional kill credits when needed", () => {
+        // This catches a bug where only one fractional leftover kill is assigned.
+        //
+        // Group 0 has 2 ships.
+        // Groups 1, 2, and 3 each deal 1 damage to Group 0.
+        //
+        // Group 0 receives 3 raw damage but only loses 2 ships.
+        //
+        // Exact kill credit against Group 0:
+        // Group 1: 1 / 3 * 2 = 0.666...
+        // Group 2: 1 / 3 * 2 = 0.666...
+        // Group 3: 1 / 3 * 2 = 0.666...
+        //
+        // Flooring gives:
+        // 0 + 0 + 0 = 0
+        //
+        // There are 2 leftover kills to assign.
+        // A broken "only assign one fractional kill" implementation would credit
+        // only 1 kill for Group 0's 2 lost ships.
+
+        const groups: TestGroup[] = [
+            makeGroup("p0", 2, 0, false, [
+                [1, 0],
+                [2, 0],
+                [3, 0],
+            ]),
+            makeGroup("p1", 1, 1, false, [
+                [0, 1],
+                [2, 1],
+                [3, 1],
+            ]),
+            makeGroup("p2", 1, 1, false, [
+                [0, 1],
+                [1, 1],
+                [3, 1],
+            ]),
+            makeGroup("p3", 1, 1, false, [
+                [0, 1],
+                [1, 1],
+                [2, 1],
+            ]),
+        ];
+
+        const result = service.calculateGroups(groups, false);
+
+        result.groups.forEach((group) => {
+            expect(group.shipsAfter).toBe(0);
+        });
+
+        const totalShipsLost = result.groups.reduce(
+            (sum, group) => sum + group.shipsLost,
+            0,
+        );
+
+        const totalShipsKilled = result.groups.reduce(
+            (sum, group) => sum + group.shipsKilled,
+            0,
+        );
+
+        expect(totalShipsLost).toBe(5);
+        expect(totalShipsKilled).toBe(totalShipsLost);
+    });
 });

--- a/common/src/services/combat.ts
+++ b/common/src/services/combat.ts
@@ -73,12 +73,9 @@ type GroupsWithDamage<
 > = [CombatGroup<ID, P, S, C>, Map<string, number>][];
 
 
-//This is specifically for crediting ship kills. There are a few scenarios to consider with the last round of combat:
-//  1) when damage > remaining ships, the remaining kills need to be not more than remaining ships,
-//      but when there are more than 2 groups doing damage, the ship kills need to also be distributed somehow
-//      between groups who did the damage
-//  2) there can still be fractional kills remaining (after kills are distributed as integers) that need to be allocated in some way if we want total #kills == #losses
-//  see "shipKill counts" in combat.spec.ts for examples
+//This is specifically for crediting ship kills:
+// -proportionally to raw damage when incoming damage exceeds the target's remaining ships.
+// -remainder handling ensures total credited kills equals actual ships destroyed.
 const allocateKillsFromDamage = (
     damageFromGroups: Map<string, number>,
     totalDamage: number,
@@ -155,7 +152,6 @@ const calculateIncomingDamages = <
 ): GroupsWithDamage<ID, P, S, C> => {
     return groups.map((group, groupIdx) => {
         const damageFromGroups = new Map<string, number>();
-        let ships = group.ships;
         let totalDamage = 0;
 
         attackingGroups.forEach((otherGroup) => {
@@ -177,7 +173,7 @@ const calculateIncomingDamages = <
         });
 
         const shipsAfterDamage = Math.max(0, group.ships - totalDamage);
-        const shipsActuallyDestroyed = ships - shipsAfterDamage; //in case damage > ships remaining, shipsDestroyed is the accurate number in order to credit kills for
+        const shipsActuallyDestroyed = group.ships - shipsAfterDamage; //in case damage > ships remaining, shipsDestroyed is the accurate number in order to credit kills for
 
         const killsFromGroups = allocateKillsFromDamage(
             damageFromGroups,

--- a/common/src/services/combat.ts
+++ b/common/src/services/combat.ts
@@ -72,6 +72,78 @@ type GroupsWithDamage<
     C extends CombatBaseCarrier<ID>,
 > = [CombatGroup<ID, P, S, C>, Map<string, number>][];
 
+
+//This is specifically for crediting ship kills. There are a few scenarios to consider with the last round of combat:
+//  1) when damage > remaining ships, the remaining kills need to be not more than remaining ships,
+//      but when there are more than 2 groups doing damage, the ship kills need to also be distributed somehow
+//      between groups who did the damage
+//  2) there can still be fractional kills remaining (after kills are distributed as integers) that need to be allocated in some way if we want total #kills == #losses
+//  see "shipKill counts" in combat.spec.ts for examples
+const allocateKillsFromDamage = (
+    damageFromGroups: Map<string, number>,
+    totalDamage: number,
+    shipsActuallyDestroyed: number,
+): Map<string, number> => {
+    const killsFromGroups = new Map<string, number>();
+
+    // Nothing was damaged/killed. Return zero kill credit for each attacker.
+    if (totalDamage <= 0 || shipsActuallyDestroyed <= 0) {
+        damageFromGroups.forEach((_, groupId) => {
+            killsFromGroups.set(groupId, 0);
+        });
+
+        return killsFromGroups;
+    }
+
+    //1) distribute credit for kills fairly between groups based on the proportion of damage they did this round.
+    //  Count up how many fractional kills are un-credited as "remainder".
+    //Example:
+    //  Target loses 5 ships.
+    //  Group A did 8 of 16 total damage -> exactKills = 2.5
+    //  Group B did 8 of 16 total damage -> exactKills = 2.5
+    const killShares = Array.from(damageFromGroups.entries()).map(
+        ([groupId, damage]) => {
+            const exactKills =
+                (damage / totalDamage) * shipsActuallyDestroyed;
+
+            const flooredKills = Math.floor(exactKills);
+
+            return {
+                groupId,
+                flooredKills,
+
+                remainder: exactKills - flooredKills,
+            };
+        },
+    );
+
+    //2) Assign fractional kills which were dropped on the floor()
+    //Give leftover kills to the groups with the largest fractional remainders.
+    //Ties are deterministic based on the existing Map insertion order.
+    //Example:
+    //  2.5 + 2.5 floors to 2 + 2 = 4,
+    //  but 5 ships were actually destroyed,
+    //  so 1 leftover kill still needs to be assigned.
+    let killsRemaining =
+        shipsActuallyDestroyed -
+        killShares.reduce((sum, share) => sum + share.flooredKills, 0);
+
+    killShares
+        .sort((a, b) => b.remainder - a.remainder)
+        .forEach((share) => {
+            const extraKill = killsRemaining > 0 ? 1 : 0;
+
+            killsFromGroups.set(
+                share.groupId,
+                share.flooredKills + extraKill,
+            );
+
+            killsRemaining -= extraKill;
+        });
+
+    return killsFromGroups;
+};
+
 const calculateIncomingDamages = <
     ID extends Id,
     P extends CombatBasePlayer<ID>,
@@ -83,8 +155,8 @@ const calculateIncomingDamages = <
 ): GroupsWithDamage<ID, P, S, C> => {
     return groups.map((group, groupIdx) => {
         const damageFromGroups = new Map<string, number>();
-
         let ships = group.ships;
+        let totalDamage = 0;
 
         attackingGroups.forEach((otherGroup) => {
             if (group.id === otherGroup.id) {
@@ -100,18 +172,25 @@ const calculateIncomingDamages = <
                 damage = dmgFromOther.total;
             }
 
-            const actualDamage = Math.min(damage, ships);
-
-            damageFromGroups.set(otherGroup.id, actualDamage);
-            ships -= actualDamage;
+            damageFromGroups.set(otherGroup.id, damage);
+            totalDamage += damage;
         });
+
+        const shipsAfterDamage = Math.max(0, group.ships - totalDamage);
+        const shipsActuallyDestroyed = ships - shipsAfterDamage; //in case damage > ships remaining, shipsDestroyed is the accurate number in order to credit kills for
+
+        const killsFromGroups = allocateKillsFromDamage(
+            damageFromGroups,
+            totalDamage,
+            shipsActuallyDestroyed,
+        );
 
         return [
             {
                 ...group,
-                ships,
+                ships: shipsAfterDamage,
             },
-            damageFromGroups,
+            killsFromGroups, //credit for shipKills distributed among groups doing damage, not to exceed actual # of ships killed.
         ];
     });
 };


### PR DESCRIPTION
Proposed fix for primary issue:   
1) kill count (for statistics) is reset after each combat round.

Subsequent complications:
1) how to distribute kill count credit when the last round of combat has more damage than ships remaining,
2) and sometimes there are multiple groups of ships doing the damage,
3) and sometimes there are fractional kills when trying to split kill credit between multiple groups.

The primary fix seems pretty straight-forward. The "subsequent complications" could have alternate approaches, and this is one possible approach.

Testing included:
1) recreating issue from beta branch (manual test localhost), to confirm kills incorrect
2) applying fix to beta branch (manual test localhost) to confirm kills correct.
3) at least 1 test in combat.spec.ts that covers each of the 4 considerations listed above.
4) npm run build and npm run check had no errors that I could see.

Feedback is appreciated. Or if you have an alternate approach that is fine too.

Edit: Fixes: #1708