### PR TITLE
Fix waypoints loop fix causing errors

### DIFF
--- a/server/services/carrierMovement.ts
+++ b/server/services/carrierMovement.ts
@@ -109,7 +109,7 @@ export default class CarrierMovementService {
 
         // If the carrier waypoints are looped then append the
         // carrier waypoint back onto the waypoint stack.
-        if (carrier.waypointsLooped && carrier.waypoints.length > 1) {
+        if (carrier.waypointsLooped && carrier.waypoints.length > 0) {
             // Set the source of the appended waypoint as the destination of the last
             // waypoint to ensure a valid state in case the source was not part of the loop.
             const lastLoopWaypoint =


### PR DESCRIPTION
(To ensure waypoints N >= 2 the check should be N > 0 [or N >= 1] as the first waypoint is spliced out before the check)