### PR TITLE
Fix established players seeing games as locked in the game list

### DIFF
--- a/client/src/stores/user.ts
+++ b/client/src/stores/user.ts
@@ -31,6 +31,7 @@ export const useUserStore = defineStore("user", () => {
     username.value = newUser.username;
     roles.value = newUser.roles;
     credits.value = newUser.credits;
+    isEstablishedPlayer.value = newUser.isEstablishedPlayer;
   };
 
   // Individual property setters

--- a/client/src/views/game/components/menu/LockedGameOverlay.vue
+++ b/client/src/views/game/components/menu/LockedGameOverlay.vue
@@ -26,9 +26,6 @@ const props = defineProps<{
 const store = useGameStore();
 const userStore = useUserStore();
 
-// Null means we do not know yet (the user request is still in flight) - do not
-// show the lock in that case, otherwise established players briefly see every
-// game as locked.
 const userIsEstablishedPlayer = computed(
   () => userStore.isEstablishedPlayer !== false,
 );

--- a/client/src/views/game/components/menu/LockedGameOverlay.vue
+++ b/client/src/views/game/components/menu/LockedGameOverlay.vue
@@ -26,7 +26,12 @@ const props = defineProps<{
 const store = useGameStore();
 const userStore = useUserStore();
 
-const userIsEstablishedPlayer = computed(() => userStore.isEstablishedPlayer);
+// Null means we do not know yet (the user request is still in flight) - do not
+// show the lock in that case, otherwise established players briefly see every
+// game as locked.
+const userIsEstablishedPlayer = computed(
+  () => userStore.isEstablishedPlayer !== false,
+);
 
 const userCanJoinGame = computed(
   () =>


### PR DESCRIPTION
As reported in 
https://discord.com/channels/686524791943069734/740693037243564142/1535008948728496440
https://discord.com/channels/686524791943069734/740693037243564142/1533208482080096390
https://discord.com/channels/686524791943069734/740693037243564142/1531931130625003630

It seemed like this was a regression from commit 15a9a9f3

Reproducible in live by navigating to https://solaris.games/#/game/list.
If you navigate from Main Menu -> Join Game, the state carries across as expected.

Adds established player state to users.ts so that it will accurately get the information as required on load.

Additionally, this will optimistically show games to be available, instead of expecting the player to be new (where most are not). It's still available via user.ts, so should fix itself in due time regardless, it just prevents a flash.

Video Demonstrating the fix for established players, and that it still shows locked for new players :
https://i.cubityfir.st/firefox_3ruqhvAcuA.mp4
