### PR TITLE
Validate player ownership before joining player socket room

### DIFF
--- a/server/sockets/socketHandlers/player.ts
+++ b/server/sockets/socketHandlers/player.ts
@@ -36,14 +36,32 @@ export class PlayerServerSocketHandler extends ServerSocketHandler<PlayerSocketE
                 socket.join(e.gameId); // Join the game room to receive game-wide messages.
 
                 if (e.playerId) {
-                    socket.join(e.playerId);
-
                     let game: Game | null = await this.gameService.getByIdLean(
                         objectIdFromString(e.gameId),
                         {
                             "settings.general.playerOnlineStatus": 1,
+                            "galaxy.players._id": 1,
+                            "galaxy.players.userId": 1,
                         },
                     );
+
+                    // Only allow the socket to join the player room if the
+                    // logged in user actually controls that player, otherwise
+                    // anyone could subscribe to another player's private events.
+                    const userId = await this.socketService.getUserId(socket);
+                    const player = game?.galaxy.players.find(
+                        (p) => p._id.toString() === e.playerId,
+                    );
+
+                    if (
+                        !userId ||
+                        !player ||
+                        player.userId?.toString() !== userId
+                    ) {
+                        return;
+                    }
+
+                    socket.join(e.playerId);
 
                     if (
                         game?.settings.general.playerOnlineStatus === "visible"


### PR DESCRIPTION
Any socket could join the room for an arbitrary player id and receive that player's private events (trades, debts, diplomacy, conversation reads, event reads). Only join the player room when the socket's logged-in user controls that player.

<img width="567" height="246" alt="image" src="https://github.com/user-attachments/assets/0831f3b4-09a9-46db-b008-7f25fda40966" />

<img width="842" height="486" alt="image" src="https://github.com/user-attachments/assets/fc039289-918b-4cf9-9b30-464039878321" />
