### PR TITLE
Validate player ownership before joining player socket room

### DIFF
--- a/server/services/index.ts
+++ b/server/services/index.ts
@@ -550,6 +550,7 @@ export default (
     const playerServerSocketHandler = new PlayerServerSocketHandler(
         socketService,
         gameService,
+        playerService,
         serverHandler,
     );
     const userServerSocketHandler = new UserServerSocketHandler(

--- a/server/sockets/socketHandlers/player.ts
+++ b/server/sockets/socketHandlers/player.ts
@@ -36,14 +36,32 @@ export class PlayerServerSocketHandler extends ServerSocketHandler<PlayerSocketE
                 socket.join(e.gameId); // Join the game room to receive game-wide messages.
 
                 if (e.playerId) {
-                    socket.join(e.playerId);
-
                     let game: Game | null = await this.gameService.getByIdLean(
                         objectIdFromString(e.gameId),
                         {
                             "settings.general.playerOnlineStatus": 1,
+                            "galaxy.players._id": 1,
+                            "galaxy.players.userId": 1,
                         },
                     );
+
+                    // Only allow the socket to join the player room if the
+                    // logged in user actually controls that player, otherwise
+                    // anyone could subscribe to another player's private events.
+                    const userId = await this.socketService.getUserId(socket);
+                    const player = game?.galaxy.players.find(
+                        (p) => p._id.toString() === e.playerId,
+                    );
+
+                    if (
+                        !userId ||
+                        !player ||
+                        player.userId?.toString() !== userId
+                    ) {
+                        return;
+                    }
+
+                    socket.join(e.playerId);
 
                     if (
                         game?.settings.general.playerOnlineStatus === "visible"

--- a/server/sockets/socketHandlers/player.ts
+++ b/server/sockets/socketHandlers/player.ts
@@ -9,11 +9,13 @@ import { objectIdFromString } from "../../services/types/DBObjectId";
 import { Game } from "../../services/types/Game";
 import { ServerHandler } from "./serverHandler";
 import { ServerSocketHandler } from "./serverSocketHandler";
+import PlayerService from "../../services/player";
 
 export class PlayerServerSocketHandler extends ServerSocketHandler<PlayerSocketEventType> {
     constructor(
         private socketService: SocketService,
         private gameService: GameService,
+        private playerService: PlayerService,
         serverHandler: ServerHandler,
     ) {
         super(serverHandler);
@@ -31,33 +33,39 @@ export class PlayerServerSocketHandler extends ServerSocketHandler<PlayerSocketE
                     return;
                 }
 
-                let socket: Socket = e.socket;
+                const socket: Socket = e.socket;
+
+                const game: Game | null = await this.gameService.getByIdLean(
+                    objectIdFromString(e.gameId),
+                    {
+                        "settings.general.playerOnlineStatus": 1,
+                        "galaxy.players._id": 1,
+                        "galaxy.players.userId": 1,
+                    },
+                );
+
+                if (!game) {
+                    return;
+                }
 
                 socket.join(e.gameId); // Join the game room to receive game-wide messages.
 
                 if (e.playerId) {
-                    let game: Game | null = await this.gameService.getByIdLean(
-                        objectIdFromString(e.gameId),
-                        {
-                            "settings.general.playerOnlineStatus": 1,
-                            "galaxy.players._id": 1,
-                            "galaxy.players.userId": 1,
-                        },
-                    );
-
                     // Only allow the socket to join the player room if the
                     // logged in user actually controls that player, otherwise
                     // anyone could subscribe to another player's private events.
                     const userId = await this.socketService.getUserId(socket);
-                    const player = game?.galaxy.players.find(
-                        (p) => p._id.toString() === e.playerId,
+
+                    if (!userId) {
+                        return;
+                    }
+
+                    const player = this.playerService.getByUserId(
+                        game,
+                        objectIdFromString(userId),
                     );
 
-                    if (
-                        !userId ||
-                        !player ||
-                        player.userId?.toString() !== userId
-                    ) {
+                    if (!player || player.userId?.toString() !== userId) {
                         return;
                     }
 


### PR DESCRIPTION
Any socket could join the room for an arbitrary player id and receive that player's private events (trades, debts, diplomacy, conversation reads, event reads). Only join the player room when the socket's logged-in user controls that player.